### PR TITLE
Fix croc channel error by matching sender/receiver configuration

### DIFF
--- a/cmd/croc/receive.go
+++ b/cmd/croc/receive.go
@@ -65,11 +65,14 @@ var ReceiveCmd = &cobra.Command{
 		crocOptions := croc.Options{
 			Curve:         "p256",
 			Debug:         false,
+			DisableLocal:  true,
+			HashAlgorithm: "xxhash",
 			IsSender:      false,
 			NoPrompt:      true,
 			Overwrite:     true,
 			RelayAddress:  relay.Address,
 			RelayPassword: relay.Password,
+			RelayPorts:    strings.Split(relay.Ports, ","),
 			SharedSecret:  sharedSecretCode,
 		}
 


### PR DESCRIPTION
The receiver was missing critical configuration options that the sender was setting, causing "room (secure channel) not ready" errors:
- Added DisableLocal: true to match sender
- Added HashAlgorithm: "xxhash" to ensure same hashing algorithm
- Added RelayPorts to connect to the same relay ports

This configuration mismatch prevented sender and receiver from establishing a secure channel on the relay server.

Fixes channel negotiation errors when using runpodctl send/receive.
