### PR TITLE
fix: receive error by switching to local croc build

### DIFF
--- a/cmd/croc/receive.go
+++ b/cmd/croc/receive.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/schollz/croc/v9/src/croc"
 	"github.com/schollz/croc/v9/src/models"
 	"github.com/spf13/cobra"
 )
@@ -62,14 +61,17 @@ var ReceiveCmd = &cobra.Command{
 		}
 		relay := relays[relayIndex]
 
-		crocOptions := croc.Options{
+		crocOptions := Options{
 			Curve:         "p256",
 			Debug:         false,
+			DisableLocal:  true,
+			HashAlgorithm: "xxhash",
 			IsSender:      false,
 			NoPrompt:      true,
 			Overwrite:     true,
 			RelayAddress:  relay.Address,
 			RelayPassword: relay.Password,
+			RelayPorts:    strings.Split(relay.Ports, ","),
 			SharedSecret:  sharedSecretCode,
 		}
 
@@ -79,7 +81,7 @@ var ReceiveCmd = &cobra.Command{
 			crocOptions.RelayAddress = ""
 		}
 
-		cr, err := croc.New(crocOptions)
+		cr, err := New(crocOptions)
 		if err != nil {
 			log.Fatalf("croc: %v", err)
 		}


### PR DESCRIPTION
# Fix receive error by switching to local croc build

This change fixes a receive-side error caused by a mismatch between our customized croc implementation and the upstream croc library. The official `croc` package and our local build no longer share the same options and constructor signatures, which leads to runtime failures when calling `croc.New()` and when initializing option fields. By switching to our local `Options` type and local `New()` constructor, the receive command now uses the correct build and avoids the incompatibility that caused the error.


## How I tested it
Test it locally. 
