### PR TITLE
Fix templateId not applying disk and volume settings from template

### DIFF
--- a/api/pod.go
+++ b/api/pod.go
@@ -140,7 +140,7 @@ func GetPods() (pods []*Pod, err error) {
 
 type CreatePodInput struct {
 	CloudType         string    `json:"cloudType"`
-	ContainerDiskInGb int       `json:"containerDiskInGb"`
+	ContainerDiskInGb int       `json:"containerDiskInGb,omitempty"`
 	DeployCost        float32   `json:"deployCost,omitempty"`
 	DockerArgs        string    `json:"dockerArgs"`
 	DataCenterId      string    `json:"dataCenterId"`
@@ -156,12 +156,37 @@ type CreatePodInput struct {
 	SupportPublicIp   bool      `json:"supportPublicIp"`
 	StartSSH          bool      `json:"startSsh"`
 	TemplateId        string    `json:"templateId"`
-	VolumeInGb        int       `json:"volumeInGb"`
-	VolumeMountPath   string    `json:"volumeMountPath"`
+	VolumeInGb        int       `json:"volumeInGb,omitempty"`
+	VolumeMountPath   string    `json:"volumeMountPath,omitempty"`
 }
 type PodEnv struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
+}
+
+// TemplateFieldFlags indicates which template-related fields were explicitly set by the user.
+type TemplateFieldFlags struct {
+	ContainerDiskChanged bool
+	VolumeSizeChanged    bool
+	VolumePathChanged    bool
+}
+
+// ClearUnchangedTemplateFields resets disk/volume fields to zero values when templateId is set
+// and those fields were not explicitly changed by the user. This allows the template's settings
+// to be used instead of CLI defaults (omitempty will exclude zero values from JSON).
+func (input *CreatePodInput) ClearUnchangedTemplateFields(flags TemplateFieldFlags) {
+	if input.TemplateId == "" {
+		return
+	}
+	if !flags.ContainerDiskChanged {
+		input.ContainerDiskInGb = 0
+	}
+	if !flags.VolumeSizeChanged {
+		input.VolumeInGb = 0
+	}
+	if !flags.VolumePathChanged {
+		input.VolumeMountPath = ""
+	}
 }
 
 func CreatePod(podInput *CreatePodInput) (pod map[string]interface{}, err error) {

--- a/cmd/pod/createPod.go
+++ b/cmd/pod/createPod.go
@@ -54,6 +54,11 @@ var CreatePodCmd = &cobra.Command{
 			VolumeMountPath:   volumeMountPath,
 			NetworkVolumeId:   networkVolumeId,
 		}
+		input.ClearUnchangedTemplateFields(api.TemplateFieldFlags{
+			ContainerDiskChanged: cmd.Flags().Changed("containerDiskSize"),
+			VolumeSizeChanged:    cmd.Flags().Changed("volumeSize"),
+			VolumePathChanged:    cmd.Flags().Changed("volumePath"),
+		})
 		if len(ports) > 0 {
 			input.Ports = strings.Join(ports, ",")
 		}

--- a/cmd/pods/createPods.go
+++ b/cmd/pods/createPods.go
@@ -50,6 +50,11 @@ var CreatePodsCmd = &cobra.Command{
 			VolumeInGb:        volumeInGb,
 			VolumeMountPath:   volumeMountPath,
 		}
+		input.ClearUnchangedTemplateFields(api.TemplateFieldFlags{
+			ContainerDiskChanged: cmd.Flags().Changed("containerDiskSize"),
+			VolumeSizeChanged:    cmd.Flags().Changed("volumeSize"),
+			VolumePathChanged:    cmd.Flags().Changed("volumePath"),
+		})
 		if len(ports) > 0 {
 			input.Ports = strings.Join(ports, ",")
 		}


### PR DESCRIPTION
## Summary
- When `--templateId` is specified, disk/volume settings from template are now used instead of being overwritten by CLI flag defaults

## Problem
CLI flags have non-zero defaults (`--containerDiskSize=20`, `--volumeSize=1`, `--volumePath=/runpod`) that were always sent to the API, overriding template settings even when user didn't explicitly set them.

## Solution
- Added `omitempty` to `containerDiskInGb`, `volumeInGb`, `volumeMountPath` JSON tags
- Added `TemplateFieldFlags` struct and `ClearUnchangedTemplateFields` method to clear these fields when templateId is set and flags were not explicitly changed
- Zero values are now omitted from JSON, allowing API to use template values

Fixes #163