### PR TITLE
Make --imageName optional when --templateId is specified

### DIFF
--- a/cmd/pod/createPod.go
+++ b/cmd/pod/createPod.go
@@ -37,6 +37,9 @@ var CreatePodCmd = &cobra.Command{
 	Short: "start a pod",
 	Long:  "start a pod from runpod.io",
 	Run: func(cmd *cobra.Command, args []string) {
+		if templateId == "" && imageName == "" {
+			cobra.CheckErr(fmt.Errorf("--imageName is required when --templateId is not specified"))
+		}
 		input := &api.CreatePodInput{
 			ContainerDiskInGb: containerDiskInGb,
 			DeployCost:        deployCost,
@@ -103,6 +106,5 @@ func init() {
 	CreatePodCmd.Flags().StringVar(&dataCenterId, "dataCenterId", "", "datacenter id to create in")
 	CreatePodCmd.Flags().BoolVar(&startSSH, "startSSH", false, "enable SSH login")
 
-	CreatePodCmd.MarkFlagRequired("gpuType")   //nolint
-	CreatePodCmd.MarkFlagRequired("imageName") //nolint
+	CreatePodCmd.MarkFlagRequired("gpuType") //nolint
 }

--- a/cmd/pods/createPods.go
+++ b/cmd/pods/createPods.go
@@ -35,6 +35,9 @@ var CreatePodsCmd = &cobra.Command{
 	Short: "create a group of pods",
 	Long:  "create a group of pods on runpod.io",
 	Run: func(cmd *cobra.Command, args []string) {
+		if templateId == "" && imageName == "" {
+			cobra.CheckErr(fmt.Errorf("--imageName is required when --templateId is not specified"))
+		}
 		gpus := strings.Split(gpuTypeId, ",")
 		gpusIndex := 0
 		input := &api.CreatePodInput{
@@ -106,7 +109,6 @@ func init() {
 	CreatePodsCmd.Flags().StringVar(&templateId, "templateId", "", "templateId to use with the pods")
 	CreatePodsCmd.Flags().StringVar(&volumeMountPath, "volumePath", "/runpod", "container volume path")
 
-	CreatePodsCmd.MarkFlagRequired("gpuType")   //nolint
-	CreatePodsCmd.MarkFlagRequired("imageName") //nolint
-	CreatePodsCmd.MarkFlagRequired("name")      //nolint
+	CreatePodsCmd.MarkFlagRequired("gpuType") //nolint
+	CreatePodsCmd.MarkFlagRequired("name")   //nolint
 }


### PR DESCRIPTION
## Summary
- Remove `--imageName` as a required flag for `create pod` and `create pods` commands
- Add runtime validation requiring `--imageName` only when `--templateId` is not specified
- When using `--templateId`, the image name is already defined in the template on RunPod UI

Fixes #162