### PR TITLE
feat: get pod json

### DIFF
--- a/cmd/pod/getPod.go
+++ b/cmd/pod/getPod.go
@@ -1,7 +1,9 @@
 package pod
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -13,6 +15,7 @@ import (
 )
 
 var AllFields bool
+var outputJSON bool
 
 var GetPodCmd = &cobra.Command{
 	Use:   "pod [podId]",
@@ -24,12 +27,18 @@ var GetPodCmd = &cobra.Command{
 		cobra.CheckErr(err)
 
 		pods = filter(pods, args)
-		toTable(pods)
+
+		if outputJSON {
+			cobra.CheckErr(toJSON(os.Stdout, pods))
+		} else {
+			toTable(pods)
+		}
 	},
 }
 
 func init() {
 	GetPodCmd.Flags().BoolVarP(&AllFields, "allfields", "a", false, "include all fields in output")
+	GetPodCmd.Flags().BoolVarP(&outputJSON, "json", "j", false, "use json as output format")
 }
 
 func filter(pods []*api.Pod, args []string) []*api.Pod {
@@ -87,4 +96,14 @@ func toTable(pods []*api.Pod) {
 	tb.AppendBulk(data)
 	format.TableDefaults(tb)
 	tb.Render()
+}
+
+func toJSON(w io.Writer, pods []*api.Pod) error {
+	b, err := json.MarshalIndent(pods, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(b)
+	return err
 }

--- a/cmd/pod/getPod_test.go
+++ b/cmd/pod/getPod_test.go
@@ -1,6 +1,8 @@
 package pod
 
 import (
+	"bytes"
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -26,11 +28,42 @@ func TestGetPod(t *testing.T) {
 			assertEqualIDs(t, []string{"p2"}, got)
 		})
 	})
+
+	t.Run("output json", func(t *testing.T) {
+		t.Run("with results", func(t *testing.T) {
+			var buf bytes.Buffer
+
+			check(t, toJSON(&buf, pods))
+
+			var got []*api.Pod
+			check(t, json.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&got))
+
+			assertEqualIDs(t, []string{"p1", "p2", "p3"}, got)
+		})
+
+		t.Run("empty output", func(t *testing.T) {
+			var buf bytes.Buffer
+
+			_ = toJSON(&buf, []*api.Pod{})
+			got := string(buf.Bytes())
+
+			if got != "[]" {
+				t.Errorf("got %v, want %v", got, "[]")
+			}
+		})
+	})
+
 }
 
 func assertEqualIDs(t *testing.T, want []string, got []*api.Pod) {
 	if !reflect.DeepEqual(want, getIDs(got)) {
 		t.Errorf("got %v, want %v", getIDs(got), want)
+	}
+}
+
+func check(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
# Add json format option to `get pod` command

Always produces a list output, even if a specific pod ID is provided. Stays semantically aligned with the text table view which also shows collection outputs regardless of matched pod(s).

Addresses https://github.com/runpod/runpodctl/issues/148#issuecomment-3771210150 but not the entire issue #148 which seems to ask for json output for _all_ commands.

## How I tested it

* Unit test
* Manual integration test against backend api

## Example output

```
runpodctl get pod --json
```

output:

```json
[
  {
    "Id": "wwp6rwl5wucng8",
    "ContainerDiskInGb": 20,
    "CostPerHr": 0.24,
    "DesiredStatus": "RUNNING",
    "DataCenterId": "",
    "DockerArgs": "",
    "Env": [
      "PUBLIC_KEY=ssh..."
    ],
    "GpuCount": 1,
    "ImageName": "runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04",
    "MemoryInGb": 31,
    "Name": "young_purple_kangaroo",
    "PodType": "RESERVED",
    "Ports": "8888/http,22/tcp",
    "VcpuCount": 6,
    "VolumeInGb": 20,
    "VolumeMountPath": "/workspace",
    "Machine": {
      "GpuDisplayName": "RTX 2000 Ada",
      "Location": "RO"
    },
    "Runtime": {
      "Ports": [
        {
          "Ip": "100.65.24.183",
          "IsIpPublic": false,
          "PrivatePort": 19123,
          "PublicPort": 60755,
          "PortType": "http"
        },
        {
          "Ip": "213.173.102.150",
          "IsIpPublic": true,
          "PrivatePort": 22,
          "PublicPort": 31696,
          "PortType": "tcp"
        },
        {
          "Ip": "100.65.24.183",
          "IsIpPublic": false,
          "PrivatePort": 8888,
          "PublicPort": 60754,
          "PortType": "http"
        }
      ]
    }
  }
]
```