### PR TITLE
feat: edit pod command (#35)

### DIFF
--- a/api/pod.go
+++ b/api/pod.go
@@ -219,6 +219,75 @@ func CreatePod(podInput *CreatePodInput) (pod map[string]interface{}, err error)
 	return
 }
 
+type PodEditJobInput struct {
+	PodId             string    `json:"podId"`
+	ContainerDiskInGb int       `json:"containerDiskInGb"`
+	DockerArgs        string    `json:"dockerArgs"`
+	Env               []*PodEnv `json:"env"`
+	ImageName         string    `json:"imageName"`
+	Ports             string    `json:"ports"`
+	VolumeInGb        int       `json:"volumeInGb"`
+	VolumeMountPath   string    `json:"volumeMountPath"`
+}
+
+type EnvironmentVariableInput struct {
+}
+
+func UpdatePod(podInput *PodEditJobInput) (pod map[string]interface{}, err error) {
+	input := Input{
+		Query: `
+		mutation podEditJob($input: PodEditJobInput!) {
+			podEditJob(input: $input) {
+			  id
+			  containerDiskInGb
+			  dockerArgs
+			  env
+			  imageName
+			  name
+			  ports
+			  volumeInGb
+			  volumeMountPath
+			}
+		}
+		`,
+		Variables: map[string]interface{}{"input": podInput},
+	}
+	res, err := Query(input)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	rawData, err := io.ReadAll(res.Body)
+	if err != nil {
+		return
+	}
+	if res.StatusCode != 200 {
+		err = fmt.Errorf("statuscode %d: %s", res.StatusCode, string(rawData))
+		return
+	}
+	data := make(map[string]interface{})
+	if err = json.Unmarshal(rawData, &data); err != nil {
+		return
+	}
+	gqlErrors, ok := data["errors"].([]interface{})
+	if ok && len(gqlErrors) > 0 {
+		firstErr, _ := gqlErrors[0].(map[string]interface{})
+		err = errors.New(firstErr["message"].(string))
+		return
+	}
+	gqldata, ok := data["data"].(map[string]interface{})
+	if !ok || gqldata == nil {
+		err = fmt.Errorf("data is nil: %s", string(rawData))
+		return
+	}
+	pod, ok = gqldata["podEditJob"].(map[string]interface{})
+	if !ok || pod == nil {
+		err = fmt.Errorf("podEditJob is nil: %s", string(rawData))
+		return
+	}
+	return
+}
+
 func StopPod(id string) (podStop map[string]interface{}, err error) {
 	input := Input{
 		Query: `

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/runpod/runpodctl/cmd/pod"
+
+	"github.com/spf13/cobra"
+)
+
+var editCmd = &cobra.Command{
+	Use:   "edit [command]",
+	Short: "edit resource",
+	Long:  "edit config for existing (deployed) resources",
+}
+
+func init() {
+	editCmd.AddCommand(pod.EditPodCmd)
+}

--- a/cmd/pod/editPod.go
+++ b/cmd/pod/editPod.go
@@ -1,0 +1,252 @@
+package pod
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/runpod/runpodctl/api"
+
+	"github.com/spf13/cobra"
+)
+
+const MaxPorts = 10
+
+type EditPodCmdConfig struct {
+	containerDiskInGb *int
+	dockerArgs        *string
+	env               *[]string
+	imageName         *string
+	ports             *[]string
+	volumeInGb        *int
+	volumeMountPath   *string
+	dryrun            bool
+}
+
+var editConf EditPodCmdConfig
+
+var EditPodCmd = &cobra.Command{
+	Use:   "pod id|name",
+	Args:  cobra.ExactArgs(1),
+	Short: "edit pod config",
+	Long:  "Edit (update) pod configuration without releasing the machine \n(may result in wiping of container disk; use a volume to persist data)",
+	Run: func(cmd *cobra.Command, args []string) {
+		setUserProviderOptions(cmd, editOptBindings)
+		cobra.CheckErr(assertValidPorts(editConf.ports))
+
+		pods, err := api.GetPods()
+		cobra.CheckErr(err)
+
+		podID := args[0]
+		pod := findPod(pods, podID)
+		if pod == nil {
+			cobra.CheckErr(fmt.Errorf("no such pod with ID or name \"%s\"", podID))
+		}
+
+		input := newInputFromPod(pod)
+		err = populatePodEditJobInput(pod, input, &editConf)
+		cobra.CheckErr(err)
+
+		if editConf.dryrun {
+			b, err := json.MarshalIndent(input, "", "  ")
+			cobra.CheckErr(err)
+			fmt.Fprint(os.Stderr, "Dryrun - edit pod request to backend (not sent):\n")
+			os.Stdout.Write(b)
+			return
+		}
+
+		fmt.Fprintf(os.Stderr, "Updating pod: %s\n", input.PodId)
+		resp, err := api.UpdatePod(input)
+		cobra.CheckErr(err)
+
+		b, err := json.MarshalIndent(resp, "", "  ")
+		cobra.CheckErr(err)
+
+		fmt.Fprint(os.Stderr, "New pod configuration::\n")
+		os.Stdout.Write(b)
+	},
+}
+
+func init() {
+	editOptBindings = make(bindings)
+	b := editOptBindings
+
+	EditPodCmd.Flags().BoolVarP(&editConf.dryrun, "dryrun", "s", false, "container volume path")
+
+	bind(b, EditPodCmd, &editConf.containerDiskInGb, "containerDiskSize", 0, "container disk size in GB")
+	bind(b, EditPodCmd, &editConf.dockerArgs, "args", "",
+		"container arguments. Use the special argument \"[]\" to clear any arguments and use "+
+			"the image's default entrypoint or CMD (if present in the image)")
+	bind(b, EditPodCmd, &editConf.env, "env", nil, "container arguments")
+	bind(b, EditPodCmd, &editConf.imageName, "imageName", "", "container image name")
+	bind(b, EditPodCmd, &editConf.ports, "ports", nil, "ports to expose; max 10 http and 10 tcp allowed; e.g. '8888/http'")
+	bind(b, EditPodCmd, &editConf.volumeInGb, "volumeSize", 0, "persistent volume disk size in GB")
+	bind(b, EditPodCmd, &editConf.volumeMountPath, "volumePath", "", "container volume path")
+}
+
+// region option binding machinery
+
+type bindings = map[string]func(cmd *cobra.Command)
+
+var editOptBindings bindings
+
+// populates the command's option struct with only what was specified by the user on the cmd line
+func setUserProviderOptions(cmd *cobra.Command, bindings bindings) {
+	for _, resolve := range bindings {
+		resolve(cmd)
+	}
+}
+
+// bind performs late binding of variables to pointer fields, meaning it will only populate fields
+// that the user has explicitly provided on the command line. Options provided by the user on the command
+// line will have non-nil pointers, the others all nil. The binding happens in two phases:
+//  1. The normal Cobra variable binding happens, which registers the options as valid for the command,
+//     and also defines which pointer field should be bound to which option.
+//  2. When the Run method of the command executes, a *resolution* step is performed, where it's figured
+//     out *which* of all the options the user actually provided on the cmd line.
+//
+// The signature mimics that of cobra's TypeVarP methods, so should be intuitive.
+// Only differences 1) pointer-to-pointer binding instead of a direct pointer has to be passed as the
+// variable to bind instead of a direct pointer (reference). The code catches such mistakes with a runtime
+// cobra error.
+// 2) a bindings map has to be passed in, so as to make testing easier and also allow this code to be
+// reused by other commands facing the same challenge.
+//
+// In short the machinery consists of three parts:
+// 1. A binding map to hold all the bound options.
+// 2. a 'bind' (ing) function for establishing option -> variable relationship.
+// 3. a resolution function to resolve the late bindings during the Run phase.
+func bind[T any](bindings bindings, cmd *cobra.Command, pp **T, name string, value T, usage string) {
+	fatalErr := fmt.Errorf("Bug: got impossible type mismatch between option binding field and value of "+
+		"type: %T for option: %v", value, name)
+
+	switch v := any(value).(type) {
+	case string:
+		cmd.Flags().String(name, v, usage)
+		bindings[name] = func(cmd *cobra.Command) {
+			if cmd.Flags().Changed(name) {
+				if field, ok := any(pp).(**string); ok {
+					s, err := cmd.Flags().GetString(name)
+					cobra.CheckErr(err)
+					*field = &s
+					return
+				}
+				cobra.CheckErr(fatalErr)
+			}
+		}
+	case int:
+		cmd.Flags().Int(name, v, usage)
+		bindings[name] = func(cmd *cobra.Command) {
+			if cmd.Flags().Changed(name) {
+				if field, ok := any(pp).(**int); ok {
+					n, err := cmd.Flags().GetInt(name)
+					cobra.CheckErr(err)
+					*field = &n
+					return
+				}
+				cobra.CheckErr(fatalErr)
+			}
+		}
+	case []string:
+		cmd.Flags().StringSlice(name, nil, usage)
+		bindings[name] = func(cmd *cobra.Command) {
+			if cmd.Flags().Changed(name) {
+				if field, ok := any(pp).(**[]string); ok {
+					slice, err := cmd.Flags().GetStringSlice(name)
+					cobra.CheckErr(err)
+					*field = &slice
+					return
+				}
+				cobra.CheckErr(fatalErr)
+			}
+		}
+	default:
+		cobra.CheckErr(fmt.Errorf("binding of %T not supported, used for binding option: %v", value, name))
+	}
+}
+
+// endregion option binding machinery
+
+func findPod(pods []*api.Pod, podID string) *api.Pod {
+	for _, pod := range pods {
+		if pod.Id == podID || pod.Name == podID {
+			return pod
+		}
+	}
+	return nil
+}
+
+// overrides the default input values (those of the existing pod) with any value(s) the user explicitly provided
+func populatePodEditJobInput(pod *api.Pod, input *api.PodEditJobInput, cfg *EditPodCmdConfig) error {
+	if cfg.ports != nil {
+		portsStr := strings.Join(*cfg.ports, ",")
+		conditionallySet(pod, &portsStr, &input.Ports)
+	}
+	conditionallySet(pod, cfg.containerDiskInGb, &input.ContainerDiskInGb)
+	conditionallySet(pod, cfg.dockerArgs, &input.DockerArgs)
+	conditionallySet(pod, cfg.imageName, &input.ImageName)
+	conditionallySet(pod, cfg.volumeMountPath, &input.VolumeMountPath)
+	conditionallySet(pod, cfg.volumeInGb, &input.VolumeInGb)
+
+	if cfg.env == nil { // sending null to the backend will make it keep the pre-existing value for the pod, where-as empty array deletes all envs.
+		return nil
+	}
+	input.Env = make([]*api.PodEnv, len(*cfg.env))
+	for i, v := range *cfg.env {
+		e := strings.Split(v, "=")
+		if len(e) != 2 {
+			return fmt.Errorf("wrong env value: %s", e)
+		}
+		input.Env[i] = &api.PodEnv{Key: e[0], Value: e[1]}
+	}
+	return nil
+}
+
+// pointers are used to identify if a flag was set by the user or not.
+// pointers have two states; assigned or not (nil). That's the only reason for pointer use and the c-like pointer gymnastics.
+func conditionallySet[T any](pod *api.Pod, configField *T, inputField *T) {
+	if configField != nil {
+		fmt.Fprintf(os.Stderr, "[*] updating (pod: %s) image: %v -> %v\n", pod.Id, *inputField, *configField)
+		*inputField = *configField
+	}
+}
+
+func newInputFromPod(pod *api.Pod) *api.PodEditJobInput {
+	return &api.PodEditJobInput{
+		PodId:             pod.Id,
+		ContainerDiskInGb: pod.ContainerDiskInGb,
+		DockerArgs:        pod.DockerArgs,
+		ImageName:         pod.ImageName,
+		Ports:             pod.Ports,
+		VolumeInGb:        pod.VolumeInGb,
+		VolumeMountPath:   pod.VolumeMountPath,
+	}
+}
+
+func assertValidPorts(ports *[]string) error {
+	if ports == nil {
+		return nil
+	}
+	var nTCP, nHTTP int
+	expr := regexp.MustCompile("^\\d+/(http|tcp)$")
+	for _, port := range *ports {
+		match := expr.FindStringSubmatch(port)
+		if match == nil {
+			return fmt.Errorf("Invalid port syntax. Must be number/http or number/tcp. Got: %s", port)
+		}
+		if match[1] == "tcp" {
+			nTCP++
+		} else if match[1] == "http" {
+			nHTTP++
+		}
+	}
+	if nTCP > MaxPorts {
+		return fmt.Errorf("Maximum number of TCP ports (%d) exceeded. %d were provided", MaxPorts, nTCP)
+	}
+	if nHTTP > MaxPorts {
+		return fmt.Errorf("Maximum number of HTTP ports (%d) exceeded. %d were provided", MaxPorts, nHTTP)
+	}
+	return nil
+}

--- a/cmd/pod/editPod_test.go
+++ b/cmd/pod/editPod_test.go
@@ -1,0 +1,228 @@
+package pod
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/runpod/runpodctl/api"
+	"github.com/spf13/cobra"
+)
+
+func TestEditPod(t *testing.T) {
+
+	t.Run("port validation", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			input   []string
+			wantErr bool
+		}{
+			{
+				name:    "http port",
+				input:   []string{"80/http"},
+				wantErr: false,
+			},
+			{
+				name:    "tcp port",
+				input:   []string{"80/tcp"},
+				wantErr: false,
+			},
+			{
+				name:    "invalid port only number",
+				input:   []string{"80"},
+				wantErr: true,
+			},
+			{
+				name:    "invalid port wrong suffix",
+				input:   []string{"80/httpx"},
+				wantErr: true,
+			},
+			{
+				name:    "max http ports exactly met",
+				input:   repeat("80/http", MaxPorts),
+				wantErr: false,
+			},
+			{
+				name:    "max tcp ports exactly met",
+				input:   repeat("80/tcp", MaxPorts),
+				wantErr: false,
+			},
+			{
+				name:    "max http ports exceeded",
+				input:   repeat("80/http", MaxPorts+1),
+				wantErr: true,
+			},
+			{
+				name:    "max tcp ports exceeded",
+				input:   repeat("80/tcp", MaxPorts+1),
+				wantErr: true,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				err := assertValidPorts(&tc.input)
+				if err == nil && tc.wantErr {
+					t.Errorf("expected error but got none")
+				} else if err != nil && !tc.wantErr {
+					t.Errorf("expected no error but one: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("option binding", func(t *testing.T) {
+		type config struct {
+			pInt   *int
+			pStr   *string
+			pSlice *[]string
+		}
+
+		tests := []struct {
+			name string
+			args []string
+			want config
+			cfg  config
+		}{
+			{
+				name: "no-args",
+				args: []string{""},
+				want: config{},
+			},
+			{
+				name: "int option",
+				args: []string{"--int", "3"},
+				want: config{pInt: ptr(3)},
+			},
+			{
+				name: "string option",
+				args: []string{"--str", "x"},
+				want: config{pStr: ptr("x")},
+			},
+			{
+				name: "slice option",
+				args: []string{"--slice", "a,b"},
+				want: config{pSlice: ptr([]string{"a", "b"})},
+			},
+			{
+				name: "only touches opts explicitly specified on cmd line",
+				args: []string{"--int", "1"},
+				want: config{pStr: ptr("don't touch"), pInt: ptr(1)},
+				cfg:  config{pStr: ptr("don't touch")},
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				// prepare
+				b := make(bindings) // clear the global for each test
+				got := tc.cfg
+
+				// act
+				cmd := &cobra.Command{Run: func(cmd *cobra.Command, args []string) {
+					setUserProviderOptions(cmd, b)
+				}}
+
+				bind(b, cmd, &got.pInt, "int", 0, "")
+				bind(b, cmd, &got.pStr, "str", "", "")
+				bind(b, cmd, &got.pSlice, "slice", nil, "")
+
+				// cobra testing boilerplate
+				defer func(orig []string) { // restore in case other tests also depend on os args
+					os.Args = orig
+				}(os.Args)
+				os.Args = append([]string{"program"}, tc.args...)
+				cmd.Execute()
+
+				// vertify
+				if !reflect.DeepEqual(tc.want, got) {
+					t.Errorf("want: %v, got: %v", tc.want, got)
+				}
+			})
+		}
+	})
+
+	t.Run("conditional input assignment", func(t *testing.T) {
+		tests := []struct {
+			name string
+			conf EditPodCmdConfig
+			want api.PodEditJobInput
+			pod  api.Pod
+		}{
+			{
+				name: "no change on nil values",
+				conf: EditPodCmdConfig{},
+				want: api.PodEditJobInput{ImageName: "alpine"},
+				pod:  api.Pod{ImageName: "alpine"},
+			},
+			{
+				name: "change on non-nil values",
+				conf: EditPodCmdConfig{imageName: ptr("ubuntu")},
+				want: api.PodEditJobInput{ImageName: "ubuntu"},
+				pod:  api.Pod{ImageName: "alpine"},
+			},
+			{
+				name: "containerDiskInGb",
+				conf: EditPodCmdConfig{containerDiskInGb: ptr(3)},
+				want: api.PodEditJobInput{ContainerDiskInGb: 3},
+			},
+			{
+				name: "dockerArgs",
+				conf: EditPodCmdConfig{dockerArgs: ptr("sleep 1")},
+				want: api.PodEditJobInput{DockerArgs: "sleep 1"},
+			},
+			{
+				name: "env",
+				conf: EditPodCmdConfig{env: ptr([]string{"foo=1", "bar=baz"})},
+				want: api.PodEditJobInput{Env: []*api.PodEnv{
+					{Key: "foo", Value: "1"},
+					{Key: "bar", Value: "baz"},
+				}},
+			},
+			{
+				name: "image",
+				conf: EditPodCmdConfig{imageName: ptr("alpine")},
+				want: api.PodEditJobInput{ImageName: "alpine"},
+			},
+			{
+				name: "ports",
+				conf: EditPodCmdConfig{ports: ptr([]string{"80/http", "22/tcp"})},
+				want: api.PodEditJobInput{Ports: "80/http,22/tcp"},
+			},
+			{
+				name: "volumeInGb",
+				conf: EditPodCmdConfig{volumeInGb: ptr(7)},
+				want: api.PodEditJobInput{VolumeInGb: 7},
+			},
+			{
+				name: "volumeInGb",
+				conf: EditPodCmdConfig{volumeMountPath: ptr("/tmp")},
+				want: api.PodEditJobInput{VolumeMountPath: "/tmp"},
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				input := newInputFromPod(&tc.pod)
+
+				populatePodEditJobInput(&tc.pod, input, &tc.conf)
+
+				if !reflect.DeepEqual(tc.want, *input) {
+					t.Errorf("want: %v, got: %v", tc.want, input)
+				}
+			})
+		}
+	})
+}
+
+func repeat(s string, n int) []string {
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = s
+	}
+	return out
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ func registerCommands() {
 	// RootCmd.AddCommand(copyCmd)
 	rootCmd.AddCommand(createCmd)
 	rootCmd.AddCommand(getCmd)
+	rootCmd.AddCommand(editCmd)
 	rootCmd.AddCommand(removeCmd)
 	rootCmd.AddCommand(startCmd)
 	rootCmd.AddCommand(stopCmd)


### PR DESCRIPTION
# Add edit pod command

Modify existing pods without having to remove the pod and reprovision new machines as a result. This is a CLI version of the same functionality in the web console, where one can change container images, ports etc without releasing the machine.

Same caveat to the web console applies; the container disk may be wiped if the backend decides it has to re-launch the container for the pod, even if on the same machine.

Closes #35 

## How I tested it
* Unit tests (many new included)
* Integration test with backend, for all options and permutations to ensure the backend behaved as expected from the command's CLI surface.

## Reviewer notes

This is a rather large commit. It is large because it expands the scope of the CLI in three dimensions:
1. A new type of backend interaction (graphql query).
2. A new top category; `edit`
3. A new sub-command to the new category `edit pod`.

The second reason it's large is because it tries to avoid the pitfalls of other commands that unfortunately mutate the backend in ways the user did not intend. For instance, by confusing template variables with CLI defaults and user specified options. For that reason a new "option binding" scaffolding was added that overcomes the main issue with Cobra; no _clean_ way to determine if an option was set by the user or if it was a result of a default value.

The third reason is because this is a _delta_ handling problem, and getting it wrong will may cause data-loss for users. That is unacceptable. Other than a lot of unit tests the new edit command also has a dry-run flag, which allows the user to **inspect** exactly what will be sent to the backend, if ever in doubt. That should minimize the risk of data loss as the user has complete visibility into precisely what a given command invocation will result in _before_ sending it.

The PR contains a good deal of documentation (comments) on the binding machinery, so with a bit of squinting, I hope it makes sense after a minute or so. If not, please ask and I'll be happy to clarify, as well as revise, if a _better_ solution can be found to "parsing and **acting** on the **user provided** options **only**".