### PR TITLE
fix: Remove unnecessary hash for Model Repo uploads and bump Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Go 1.24
+      - name: Setup Go 1.25.7
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version: 1.25.7
       # You can test your matrix by printing the current Go version
       - name: Display Go version
         run: go version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.x"
+          go-version: "1.25.7"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/api/model.go
+++ b/api/model.go
@@ -201,7 +201,6 @@ type CreateModelRepoUploadInput struct {
 	Name                string                 `json:"name,omitempty"`
 	FileName            string                 `json:"fileName"`
 	FileSizeBytes       string                 `json:"fileSizeBytes"`
-	ModelVersionHash    string                 `json:"modelVersionHash,omitempty"`
 	PartSizeBytes       string                 `json:"partSizeBytes,omitempty"`
 	ContentType         string                 `json:"contentType,omitempty"`
 	Metadata            map[string]interface{} `json:"metadata,omitempty"`
@@ -648,7 +647,6 @@ func CreateModelRepoUpload(input *CreateModelRepoUploadInput) (*ModelRepoMutatio
 	addString("contentType", input.ContentType)
 	addString("credentialType", input.CredentialType)
 	addString("credentialReference", input.CredentialReference)
-	addString("modelVersionHash", input.ModelVersionHash)
 
 	if len(input.Metadata) > 0 {
 		payload["metadata"] = input.Metadata

--- a/cmd/model/addModelToRepo.go
+++ b/cmd/model/addModelToRepo.go
@@ -258,15 +258,10 @@ func collectModelFiles(dir string) ([]modelFile, error) {
 }
 
 func uploadModelFiles(files []modelFile, baseInput *api.CreateModelRepoUploadInput) error {
-	var modelVersionHash string
-
 	for _, file := range files {
 		input := *baseInput
 		input.FileName = file.RelativePath
 		input.FileSizeBytes = strconv.FormatInt(file.Size, 10)
-		if modelVersionHash != "" {
-			input.ModelVersionHash = modelVersionHash
-		}
 
 		result, err := api.CreateModelRepoUpload(&input)
 		if err != nil {
@@ -274,12 +269,6 @@ func uploadModelFiles(files []modelFile, baseInput *api.CreateModelRepoUploadInp
 		}
 		if result.Upload == nil {
 			return fmt.Errorf("upload response missing upload session details for %s", file.RelativePath)
-		}
-		if modelVersionHash == "" {
-			if result.Version == nil || result.Version.Hash == "" {
-				return fmt.Errorf("upload response missing model version hash for %s", file.RelativePath)
-			}
-			modelVersionHash = result.Version.Hash
 		}
 
 		if err = completeModelUpload(result.Upload, file.AbsolutePath); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runpod/runpodctl
 
-go 1.24
+go 1.25.7
 
 require (
 	github.com/denisbrodbeck/machineid v1.0.1


### PR DESCRIPTION
# Remove unnecessary hash for Model Repo uploads and bump Go version

Model Repo uploads do not accept a hash, causing an error if they are specified. Do not specify them.

Bump Go version as well.

## How I tested it

Local dev