### PR TITLE
feat(pod): add list filters and default to running pods

### DIFF
--- a/cmd/pod/list.go
+++ b/cmd/pod/list.go
@@ -1,6 +1,11 @@
 package pod
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/runpod/runpodctl/internal/api"
 	"github.com/runpod/runpodctl/internal/output"
 
@@ -15,18 +20,34 @@ var listCmd = &cobra.Command{
 	RunE:  runList,
 }
 
+type podListOutput struct {
+	ID            string      `json:"id"`
+	Name          string      `json:"name"`
+	DesiredStatus string      `json:"desiredStatus"`
+	ImageName     string      `json:"imageName"`
+	GpuID         string      `json:"gpuId,omitempty"`
+	GpuCount      int         `json:"gpuCount"`
+	VolumeInGb    int         `json:"volumeInGb"`
+	CostPerHr     float64     `json:"costPerHr,omitempty"`
+	CreatedAt     interface{} `json:"createdAt,omitempty"`
+}
+
 var (
-	listComputeType          string
-	listName                 string
-	listIncludeMachine       bool
-	listIncludeNetworkVolume bool
+	listComputeType  string
+	listName         string
+	listStatus       string
+	listSince        string
+	listCreatedAfter string
+	listAll          bool
 )
 
 func init() {
 	listCmd.Flags().StringVar(&listComputeType, "compute-type", "", "filter by compute type (GPU or CPU)")
 	listCmd.Flags().StringVar(&listName, "name", "", "filter by pod name")
-	listCmd.Flags().BoolVar(&listIncludeMachine, "include-machine", false, "include machine info")
-	listCmd.Flags().BoolVar(&listIncludeNetworkVolume, "include-network-volume", false, "include network volume info")
+	listCmd.Flags().StringVar(&listStatus, "status", "", "filter by desired status (e.g. RUNNING, EXITED)")
+	listCmd.Flags().StringVar(&listSince, "since", "", "filter pods created within duration (e.g. 1h, 7d)")
+	listCmd.Flags().StringVar(&listCreatedAfter, "created-after", "", "filter pods created after date (e.g. 2025-01-15)")
+	listCmd.Flags().BoolVarP(&listAll, "all", "a", false, "show all pods including exited (default: running only)")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -37,10 +58,8 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := &api.PodListOptions{
-		ComputeType:          listComputeType,
-		Name:                 listName,
-		IncludeMachine:       listIncludeMachine,
-		IncludeNetworkVolume: listIncludeNetworkVolume,
+		ComputeType: listComputeType,
+		Name:        listName,
 	}
 
 	pods, err := client.ListPods(opts)
@@ -49,6 +68,98 @@ func runList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Determine time cutoff from --since and --created-after
+	var cutoff time.Time
+	if listSince != "" {
+		d, err := parseDuration(listSince)
+		if err != nil {
+			output.Error(err)
+			return err
+		}
+		cutoff = time.Now().Add(-d)
+	}
+	if listCreatedAfter != "" {
+		t, err := time.Parse("2006-01-02", listCreatedAfter)
+		if err != nil {
+			err = fmt.Errorf("invalid --created-after format, expected YYYY-MM-DD: %w", err)
+			output.Error(err)
+			return err
+		}
+		if cutoff.IsZero() || t.After(cutoff) {
+			cutoff = t
+		}
+	}
+
+	statusFilter := strings.ToUpper(listStatus)
+	if statusFilter == "" && !listAll {
+		statusFilter = "RUNNING"
+	}
+
+	items := make([]podListOutput, 0, len(pods))
+	for _, p := range pods {
+		if statusFilter != "" && !strings.EqualFold(p.DesiredStatus, statusFilter) {
+			continue
+		}
+		if !cutoff.IsZero() {
+			created := parseCreatedAt(p.CreatedAt)
+			if created.IsZero() || created.Before(cutoff) {
+				continue
+			}
+		}
+
+		items = append(items, podListOutput{
+			ID:            p.ID,
+			Name:          p.Name,
+			DesiredStatus: p.DesiredStatus,
+			ImageName:     p.ImageName,
+			GpuID:         p.GpuTypeID,
+			GpuCount:      p.GpuCount,
+			VolumeInGb:    p.VolumeInGb,
+			CostPerHr:     p.CostPerHr,
+			CreatedAt:     p.CreatedAt,
+		})
+	}
+
 	format := output.ParseFormat(cmd.Flag("output").Value.String())
-	return output.Print(pods, &output.Config{Format: format})
+	return output.Print(items, &output.Config{Format: format})
+}
+
+// parseDuration parses a duration string like "1h", "7d", "30d".
+// Supported suffixes: h (hours), d (days).
+func parseDuration(s string) (time.Duration, error) {
+	if len(s) < 2 {
+		return 0, fmt.Errorf("invalid duration %q: too short", s)
+	}
+	suffix := s[len(s)-1]
+	numStr := s[:len(s)-1]
+	n, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	switch suffix {
+	case 'h':
+		return time.Duration(n) * time.Hour, nil
+	case 'd':
+		return time.Duration(n) * 24 * time.Hour, nil
+	default:
+		return 0, fmt.Errorf("invalid duration %q: unsupported suffix %q (use h or d)", s, string(suffix))
+	}
+}
+
+// parseCreatedAt parses the createdAt field from the API response.
+// It handles RFC3339 strings and Unix timestamp strings.
+func parseCreatedAt(v interface{}) time.Time {
+	s, ok := v.(string)
+	if !ok {
+		return time.Time{}
+	}
+	// Try RFC3339
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
+	}
+	// Try Unix timestamp string
+	if ts, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return time.Unix(ts, 0)
+	}
+	return time.Time{}
 }

--- a/cmd/pod/list.go
+++ b/cmd/pod/list.go
@@ -90,6 +90,12 @@ func runList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if listSince != "" && listCreatedAfter != "" {
+		err := fmt.Errorf("--since and --created-after cannot be used together")
+		output.Error(err)
+		return err
+	}
+
 	if listAll && listStatus != "" {
 		err := fmt.Errorf("--all and --status cannot be used together")
 		output.Error(err)

--- a/cmd/pod/list.go
+++ b/cmd/pod/list.go
@@ -29,7 +29,7 @@ type podListOutput struct {
 	GpuCount      int         `json:"gpuCount"`
 	VolumeInGb    int         `json:"volumeInGb"`
 	CostPerHr     float64     `json:"costPerHr,omitempty"`
-	CreatedAt     interface{} `json:"createdAt,omitempty"`
+	CreatedAt     string      `json:"createdAt,omitempty"`
 }
 
 var (
@@ -90,7 +90,13 @@ func runList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	statusFilter := strings.ToUpper(listStatus)
+	if listAll && listStatus != "" {
+		err := fmt.Errorf("--all and --status cannot be used together")
+		output.Error(err)
+		return err
+	}
+
+	statusFilter := listStatus
 	if statusFilter == "" && !listAll {
 		statusFilter = "RUNNING"
 	}
@@ -107,6 +113,12 @@ func runList(cmd *cobra.Command, args []string) error {
 			}
 		}
 
+		ct := parseCreatedAt(p.CreatedAt)
+		var createdAtStr string
+		if !ct.IsZero() {
+			createdAtStr = ct.UTC().Format(time.RFC3339)
+		}
+
 		items = append(items, podListOutput{
 			ID:            p.ID,
 			Name:          p.Name,
@@ -116,7 +128,7 @@ func runList(cmd *cobra.Command, args []string) error {
 			GpuCount:      p.GpuCount,
 			VolumeInGb:    p.VolumeInGb,
 			CostPerHr:     p.CostPerHr,
-			CreatedAt:     p.CreatedAt,
+			CreatedAt:     createdAtStr,
 		})
 	}
 
@@ -124,26 +136,27 @@ func runList(cmd *cobra.Command, args []string) error {
 	return output.Print(items, &output.Config{Format: format})
 }
 
-// parseDuration parses a duration string like "1h", "7d", "30d".
-// Supported suffixes: h (hours), d (days).
+// parseDuration parses a duration string like "30m", "1h", "1h30m", "7d".
+// It handles "d" (days) specially and falls back to time.ParseDuration for everything else.
 func parseDuration(s string) (time.Duration, error) {
-	if len(s) < 2 {
-		return 0, fmt.Errorf("invalid duration %q: too short", s)
-	}
-	suffix := s[len(s)-1]
-	numStr := s[:len(s)-1]
-	n, err := strconv.Atoi(numStr)
-	if err != nil {
-		return 0, fmt.Errorf("invalid duration %q: %w", s, err)
-	}
-	switch suffix {
-	case 'h':
-		return time.Duration(n) * time.Hour, nil
-	case 'd':
+	if strings.HasSuffix(s, "d") {
+		n, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		if n <= 0 {
+			return 0, fmt.Errorf("invalid duration %q: must be positive", s)
+		}
 		return time.Duration(n) * 24 * time.Hour, nil
-	default:
-		return 0, fmt.Errorf("invalid duration %q: unsupported suffix %q (use h or d)", s, string(suffix))
 	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: supported formats are e.g. 30m, 2h, 7d", s)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid duration %q: must be positive", s)
+	}
+	return d, nil
 }
 
 // parseCreatedAt parses the createdAt field from the API response.

--- a/cmd/pod/pod_test.go
+++ b/cmd/pod/pod_test.go
@@ -48,11 +48,21 @@ func TestListCmd_Flags(t *testing.T) {
 	if flags.Lookup("name") == nil {
 		t.Error("expected --name flag")
 	}
-	if flags.Lookup("include-machine") == nil {
-		t.Error("expected --include-machine flag")
+	if flags.Lookup("status") == nil {
+		t.Error("expected --status flag")
 	}
-	if flags.Lookup("include-network-volume") == nil {
-		t.Error("expected --include-network-volume flag")
+	if flags.Lookup("since") == nil {
+		t.Error("expected --since flag")
+	}
+	if flags.Lookup("created-after") == nil {
+		t.Error("expected --created-after flag")
+	}
+	if flags.Lookup("all") == nil {
+		t.Error("expected --all flag")
+	}
+	allFlag := flags.ShorthandLookup("a")
+	if allFlag == nil {
+		t.Error("expected -a shorthand for --all")
 	}
 }
 

--- a/cmd/pod/pod_test.go
+++ b/cmd/pod/pod_test.go
@@ -3,6 +3,7 @@ package pod
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -138,5 +139,109 @@ func TestPodCmd_Help(t *testing.T) {
 	}
 	if output == "" {
 		t.Error("expected help output")
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		// valid inputs
+		{input: "1h", want: time.Hour},
+		{input: "7d", want: 7 * 24 * time.Hour},
+		{input: "30m", want: 30 * time.Minute},
+		{input: "1h30m", want: time.Hour + 30*time.Minute},
+		{input: "2h", want: 2 * time.Hour},
+		{input: "1d", want: 24 * time.Hour},
+
+		// invalid inputs
+		{input: "-1d", wantErr: true},
+		{input: "0h", wantErr: true},
+		{input: "0d", wantErr: true},
+		{input: "abc", wantErr: true},
+		{input: "", wantErr: true},
+		{input: "-2h", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseDuration(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseDuration(%q) expected error, got %v", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseDuration(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseDuration(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCreatedAt(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		wantZero bool
+		wantTime time.Time
+	}{
+		{
+			name:     "RFC3339 string",
+			input:    "2025-06-15T10:30:00Z",
+			wantZero: false,
+			wantTime: time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "Unix timestamp string",
+			input:    "1750000000",
+			wantZero: false,
+			wantTime: time.Unix(1750000000, 0),
+		},
+		{
+			name:     "invalid string",
+			input:    "not-a-date",
+			wantZero: true,
+		},
+		{
+			name:     "nil value",
+			input:    nil,
+			wantZero: true,
+		},
+		{
+			name:     "non-string type (int)",
+			input:    12345,
+			wantZero: true,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			wantZero: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCreatedAt(tt.input)
+			if tt.wantZero {
+				if !got.IsZero() {
+					t.Errorf("parseCreatedAt(%v) = %v, want zero time", tt.input, got)
+				}
+				return
+			}
+			if got.IsZero() {
+				t.Errorf("parseCreatedAt(%v) returned zero time, want %v", tt.input, tt.wantTime)
+				return
+			}
+			if !got.Equal(tt.wantTime) {
+				t.Errorf("parseCreatedAt(%v) = %v, want %v", tt.input, got, tt.wantTime)
+			}
+		})
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,6 +71,8 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	// disable default completion command, we have our own
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	// commands emit JSON errors via output.Error; silence Cobra's plain-text re-print
+	rootCmd.SilenceErrors = true
 	registerCommands()
 }
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -61,15 +61,6 @@ func TestE2E_PodListWithOptions(t *testing.T) {
 		t.Fatalf("failed to create client: %v", err)
 	}
 
-	// test with include machine
-	pods, err := client.ListPods(&api.PodListOptions{
-		IncludeMachine: true,
-	})
-	if err != nil {
-		t.Fatalf("failed to list pods with machine info: %v", err)
-	}
-	t.Logf("found %d pods with machine info", len(pods))
-
 	// test with compute type filter
 	gpuPods, err := client.ListPods(&api.PodListOptions{
 		ComputeType: "GPU",

--- a/internal/api/pods.go
+++ b/internal/api/pods.go
@@ -74,12 +74,6 @@ func (c *Client) ListPods(opts *PodListOptions) ([]Pod, error) {
 		if opts.Name != "" {
 			params.Set("name", opts.Name)
 		}
-		if opts.IncludeMachine {
-			params.Set("includeMachine", "true")
-		}
-		if opts.IncludeNetworkVolume {
-			params.Set("includeNetworkVolume", "true")
-		}
 		for _, gpuType := range opts.GpuTypeIDs {
 			params.Add("gpuTypeId", gpuType)
 		}
@@ -103,12 +97,10 @@ func (c *Client) ListPods(opts *PodListOptions) ([]Pod, error) {
 
 // PodListOptions are options for listing pods
 type PodListOptions struct {
-	ComputeType          string
-	GpuTypeIDs           []string
-	DataCenterIDs        []string
-	Name                 string
-	IncludeMachine       bool
-	IncludeNetworkVolume bool
+	ComputeType   string
+	GpuTypeIDs    []string
+	DataCenterIDs []string
+	Name          string
 }
 
 // GetPod returns a single pod by ID

--- a/internal/api/pods_test.go
+++ b/internal/api/pods_test.go
@@ -45,9 +45,6 @@ func TestListPods_WithOptions(t *testing.T) {
 		if query.Get("computeType") != "GPU" {
 			t.Errorf("expected computeType=GPU")
 		}
-		if query.Get("includeMachine") != "true" {
-			t.Errorf("expected includeMachine=true")
-		}
 		json.NewEncoder(w).Encode([]Pod{})
 	}))
 	defer server.Close()
@@ -58,8 +55,7 @@ func TestListPods_WithOptions(t *testing.T) {
 	client.baseURL = server.URL
 
 	opts := &PodListOptions{
-		ComputeType:    "GPU",
-		IncludeMachine: true,
+		ComputeType: "GPU",
 	}
 	_, err := client.ListPods(opts)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `--status`, `--since`, `--created-after`, and `--all` flags to `pod list`
- Default behavior now shows only running pods (like `docker ps`)
- Use `--all` or `--status exited` to see non-running pods
- Slim down output fields to essential info (id, name, status, image, gpu, cost)

## Usage
```bash
runpodctl pod list                              # running pods only (default)
runpodctl pod list --all                        # all pods including exited
runpodctl pod list --status exited              # filter by status
runpodctl pod list --since 24h                  # pods created in last 24 hours
runpodctl pod list --created-after 2025-01-15   # pods created after date
```

## Test plan
- [x] Unit tests pass (`go test ./cmd/pod/...`)
- [ ] E2E: `pod list` returns only running pods
- [ ] E2E: `pod list --all` includes exited pods