### PR TITLE
fix: correct download URL pattern in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -98,24 +98,24 @@ download_url_constructor() {
     local arch_type=$(uname -m)
 
     if [[ "$os_type" == "darwin" ]]; then
+        # macOS uses a universal binary (all architectures)
+        DOWNLOAD_URL="https://github.com/runpod/runpodctl/releases/download/${VERSION}/runpodctl-darwin-all.tar.gz"
+        return
+    elif [[ "$os_type" == "linux" ]]; then
         if [[ "$arch_type" == "x86_64" ]]; then
-            arch_type="amd64"  # For Intel-based Mac
-        elif [[ "$arch_type" == "arm64" ]]; then
-            arch_type="arm64"  # For ARM-based Mac (Apple Silicon)
+            arch_type="amd64"
+        elif [[ "$arch_type" == "aarch64" || "$arch_type" == "arm64" ]]; then
+            arch_type="arm64"
         else
-            echo "Unsupported macOS architecture: $arch_type"
+            echo "Unsupported Linux architecture: $arch_type"
             exit 1
         fi
-    elif [[ "$os_type" == "linux" ]]; then
-        arch_type="amd64"  # Assuming amd64 architecture for Linux
     else
         echo "Unsupported operating system: $os_type"
         exit 1
     fi
 
-    local version_without_v_prefix=${VERSION#v}
-
-    DOWNLOAD_URL="https://github.com/runpod/runpodctl/releases/download/${VERSION}/runpodctl_${version_without_v_prefix}_${os_type}_${arch_type}.tar.gz"
+    DOWNLOAD_URL="https://github.com/runpod/runpodctl/releases/download/${VERSION}/runpodctl-${os_type}-${arch_type}.tar.gz"
 }
 
 # ---------------------------- Download & Install ---------------------------- #


### PR DESCRIPTION
## Summary
- Fix download URL to match goreleaser's naming: `runpodctl-{os}-{arch}.tar.gz` (dashes, no version in filename)
- Use `darwin-all` universal binary for macOS instead of per-arch builds
- Add `aarch64`/`arm64` support for Linux

## What was broken

The install script constructed URLs like:
```
runpodctl_1.14.15_linux_amd64.tar.gz  (underscores, version in filename)
```

But goreleaser produces:
```
runpodctl-linux-amd64.tar.gz  (dashes, no version)
```

This caused a 404, leaving the old pre-installed binary on PATH.

## Validated
- macOS `darwin-all` URL → 200, binary runs correctly (`runpodctl 2.1.0-0e6667c`)
- Linux `linux-amd64` URL → 200
- Linux `linux-arm64` URL → 200

Fixes #221
Fixes #150