### PR TITLE
fix: use github app token for homebrew tap push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,15 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}   # build the tagged commit
 
+      - name: Generate homebrew tap token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: runpod
+          repositories: homebrew-runpodctl
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -34,3 +43,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,6 +55,7 @@ homebrew_casks:
     repository:
       owner: runpod
       name: homebrew-runpodctl
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     commit_author:
       name: runpod
       email: support@runpod.io


### PR DESCRIPTION
## Summary
- The release workflow was broken for homebrew tap updates since commit b0e2a31 (Sep 2025) which switched from `PUBLISHER_TOKEN` to `GITHUB_TOKEN`
- `GITHUB_TOKEN` lacks cross-repo permissions to push to `runpod/homebrew-runpodctl`
- Uses the existing org secrets `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` with `actions/create-github-app-token` to generate a scoped, short-lived token
- GoReleaser uses this token exclusively for the homebrew tap push

## Test plan
- [ ] Verify the GitHub App is installed on the `runpod` org with access to `homebrew-runpodctl` (Contents: write)
- [ ] Merge this PR and the install script fix PR
- [ ] Create a new release tag to trigger the workflow
- [ ] Confirm the "Generate homebrew tap token" step succeeds
- [ ] Confirm GoReleaser pushes the cask update to `runpod/homebrew-runpodctl`