### PR TITLE
fix: embed CA certificates for environments without system certs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	golang.org/x/crypto v0.35.0
+	golang.org/x/crypto/x509roots/fallback v0.0.0-20260213171211-a408498e5541
 	golang.org/x/mod v0.22.0
 	golang.org/x/time v0.5.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDf
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
 golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
+golang.org/x/crypto/x509roots/fallback v0.0.0-20260213171211-a408498e5541 h1:FmKxj9ocLKn45jiR2jQMwCVhDvaK7fKQFzfuT9GvyK8=
+golang.org/x/crypto/x509roots/fallback v0.0.0-20260213171211-a408498e5541/go.mod h1:+UoQFNBq2p2wO+Q6ddVtYc25GZ6VNdOMyyrd4nrqrKs=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,12 @@
 package main
 
-import "github.com/runpod/runpodctl/cmd"
+import (
+	"github.com/runpod/runpodctl/cmd"
+
+	// Embed Mozilla CA certificates as fallback for environments without system certs
+	// (e.g. minimal Docker images like ubuntu:22.04 without ca-certificates installed)
+	_ "golang.org/x/crypto/x509roots/fallback"
+)
 
 // Version is set at build time via ldflags
 var Version = "v2.0.0-beta.1"


### PR DESCRIPTION
## Summary
- Import `golang.org/x/crypto/x509roots/fallback` to embed Mozilla's CA certificate bundle in the binary
- This allows runpodctl to make HTTPS calls in environments without `ca-certificates` installed (e.g. minimal Docker images like `ubuntu:22.04`)
- When system certs are available, they are used as normal — the embedded bundle is only a fallback
- Binary size increase: ~200KB

## The problem

Running `runpodctl` from inside a container based on a minimal image (without `ca-certificates`) fails:

```
Error: Post "https://api.runpod.io/graphql": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

## Verified

Tested on a live Runpod pod:

1. Removed `ca-certificates` from a running pod to simulate bare `ubuntu:22.04`
2. Old binary → `x509: certificate signed by unknown authority`
3. New binary (with embedded certs) → TLS succeeds, gets `401` (expected with fake API key)

Fixes #149