### PR TITLE
fix: use pull request for homebrew cask update

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,6 +56,8 @@ homebrew_casks:
       owner: runpod
       name: homebrew-runpodctl
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      pull_request:
+        enabled: true
     commit_author:
       name: runpod
       email: support@runpod.io


### PR DESCRIPTION
## Summary
- The v2.1.1 release showed that `homebrew-runpodctl` has branch protection requiring changes via PR
- Adds `pull_request.enabled: true` to the goreleaser homebrew_casks config so it creates a PR instead of pushing directly
- Follows up on #237 which fixed the token generation

## Context
v2.1.1 release partially succeeded — the GitHub release and artifacts were published, but the homebrew cask update failed with:
```
409 Repository rule violations found - Changes must be made through a pull request.
```

## Test plan
- [ ] Merge this PR
- [ ] Delete and re-tag v2.1.1 (or create v2.1.2)
- [ ] Verify GoReleaser creates a PR on `runpod/homebrew-runpodctl` instead of pushing directly