### PR TITLE
feat: unified integration matrix with gated CI signaling

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,69 @@
+name: Integration Test Matrix
+
+on:
+  push:
+    branches: [ main, feat-ci-tests, feat-install-noroot ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: integration-tests-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  test-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        user_mode: [root, non-root]
+    container:
+      image: alpine:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          apk add --no-cache bash wget grep sed tar git coreutils jq curl
+      - name: Setup Non-Root User and Workspace
+        if: matrix.user_mode == 'non-root'
+        run: |
+          adduser -D -u 1000 tester
+          mkdir -p /tmp/runpodctl-test
+          cp -r . /tmp/runpodctl-test/
+          chmod +x /tmp/runpodctl-test/tests/integration_suite.sh
+          chown -R tester:tester /tmp/runpodctl-test
+      - name: Run Unified Tests
+        env:
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+        run: |
+          chmod +x tests/integration_suite.sh
+          if [ "${{ matrix.user_mode }}" == "root" ]; then
+            ./tests/integration_suite.sh
+          else
+            su tester -c "cd /tmp/runpodctl-test && ./tests/integration_suite.sh"
+          fi
+      - name: Post-Run Cleanup (Emergency)
+        if: always()
+        env:
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+        run: |
+          # Try to find and kill any leaked pods if runpodctl was installed
+          RP=""
+          if [ -f "/usr/local/bin/runpodctl" ]; then
+            RP="/usr/local/bin/runpodctl"
+          elif [ -f "$HOME/.local/bin/runpodctl" ]; then
+            RP="$HOME/.local/bin/runpodctl"
+          elif [ -f "/home/tester/.local/bin/runpodctl" ]; then
+            RP="/home/tester/.local/bin/runpodctl"
+          fi
+          
+          if [ -n "$RP" ] && [ -n "$RUNPOD_API_KEY" ]; then
+            echo "Ensuring all CI resources are removed..."
+            $RP pod list --output json 2>/dev/null | jq -r '.[].id' | xargs -I {} $RP pod delete {} || true
+            $RP serverless list --output json 2>/dev/null | jq -r '.[].id' | xargs -I {} $RP serverless delete {} || true
+          fi

--- a/install.sh
+++ b/install.sh
@@ -10,22 +10,68 @@
 # Requirements:
 #   - Bash shell
 #   - Internet connection
-#   - Homebrew (for macOS users)
-#   - jq (for JSON processing, will be installed automatically)
+#   - tar, wget, grep, sed (standard on most systems)
 #
 # Supported Platforms:
-#   - Linux (amd64)
-#   - macOS (Intel and Apple Silicon)
+#   - Linux (amd64, arm64)
+#   - macOS (Universal binary)
 
 set -e
-REQUIRED_PKGS=("jq")  # Add all required packages to this list, separated by spaces.
 
+# ---------------------------- Environment Setup ----------------------------- #
+detect_install_dir() {
+    if [ "$EUID" -eq 0 ]; then
+        INSTALL_DIR="/usr/local/bin"
+    else
+        # Tiered Path Discovery: Prefer directories already in PATH
+        local preferred_dirs=("$HOME/.local/bin" "$HOME/bin" "$HOME/.bin")
+        INSTALL_DIR=""
+
+        for dir in "${preferred_dirs[@]}"; do
+            if [[ ":$PATH:" == *":$dir:"* ]] && ([ -d "$dir" ] && [ -w "$dir" ]); then
+                INSTALL_DIR="$dir"
+                break
+            fi
+        done
+
+        # If none found in PATH, check if they exist and are writable
+        if [ -z "$INSTALL_DIR" ]; then
+            for dir in "${preferred_dirs[@]}"; do
+                if [ -d "$dir" ] && [ -w "$dir" ]; then
+                    INSTALL_DIR="$dir"
+                    break
+                fi
+            done
+        fi
+
+        # Fallback to creating ~/.local/bin
+        if [ -z "$INSTALL_DIR" ]; then
+            INSTALL_DIR="$HOME/.local/bin"
+            mkdir -p "$INSTALL_DIR"
+        fi
+
+        echo "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓"
+        echo "┃  USER-SPACE INSTALLATION DETECTED                          ┃"
+        echo "┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫"
+        echo "┃ Target: $INSTALL_DIR ┃"
+        echo "┃                                                            ┃"
+        echo "┃ To install for ALL USERS (requires root), please run:      ┃"
+        echo "┃ sudo bash <(wget -qO- cli.runpod.io) # or curl -sL         ┃"
+        echo "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛"
+
+        # Check if INSTALL_DIR is in PATH
+        if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+            echo "Warning: $INSTALL_DIR is not in your PATH."
+            echo "Add it to your profile (e.g., ~/.bashrc or ~/.zshrc):"
+            echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+        fi
+    fi
+}
 
 # -------------------------------- Check Root -------------------------------- #
 check_root() {
     if [ "$EUID" -ne 0 ]; then
-        echo "Please run as root with sudo."
-        exit 1
+        echo "Note: Running as non-root. Installing to user-space."
     fi
 }
 
@@ -33,58 +79,37 @@ check_root() {
 install_with_brew() {
     local package=$1
     echo "Installing $package with Homebrew..."
-    local original_user=$(logname)
-    su - "$original_user" -c "brew install $package"
+    local original_user
+    original_user=$(logname 2>/dev/null || echo "$SUDO_USER")
+    
+    if [[ -n "$original_user" && "$original_user" != "root" ]]; then
+        su - "$original_user" -c "brew install \"$package\""
+    else
+        brew install "$package"
+    fi
 }
 
 # ------------------------- Install Required Packages ------------------------ #
-install_package() {
-    local package=$1
-    echo "Installing $package..."
-
-    case $OSTYPE in
-        linux-gnu*)
-            if [[ -f /etc/debian_version ]]; then
-                apt-get update && apt-get install -y "$package"
-            elif [[ -f /etc/redhat-release ]]; then
-                yum install -y "$package"
-            elif [[ -f /etc/fedora-release ]]; then
-                dnf install -y "$package"
-            else
-                echo "Unsupported Linux distribution for automatic installation of $package."
-                exit 1
-            fi
-            ;;
-        darwin*)
-            install_with_brew "$package"
-            ;;
-        *)
-            echo "Unsupported OS for automatic installation of $package."
-            exit 1
-            ;;
-    esac
-}
-
 check_system_requirements() {
-    local all_installed=true
-
-    for pkg in "${REQUIRED_PKGS[@]}"; do
-        if ! command -v "$pkg" >/dev/null 2>&1; then
-            echo "$pkg is not installed."
-            install_package "$pkg"
-            all_installed=false
+    local missing_pkgs=()
+    for cmd in wget tar grep sed; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            missing_pkgs+=("$cmd")
         fi
     done
 
-    if [ "$all_installed" = true ]; then
-        echo "All system requirements satisfied."
+    if [ ${#missing_pkgs[@]} -ne 0 ]; then
+        echo "Error: Missing required commands: ${missing_pkgs[*]}"
+        exit 1
     fi
 }
 
 # ----------------------------- runpodctl Version ---------------------------- #
 fetch_latest_version() {
     local version_url="https://api.github.com/repos/runpod/runpodctl/releases/latest"
-    VERSION=$(wget -q -O- "$version_url" | jq -r '.tag_name')
+    # Using grep/sed instead of jq for zero-dependency parsing
+    VERSION=$(wget -q -O- "$version_url" | grep '"tag_name":' | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
+    
     if [ -z "$VERSION" ]; then
         echo "Failed to fetch the latest version of runpodctl."
         exit 1
@@ -97,50 +122,113 @@ download_url_constructor() {
     local os_type=$(uname -s | tr '[:upper:]' '[:lower:]')
     local arch_type=$(uname -m)
 
-    if [[ "$os_type" == "darwin" ]]; then
-        if [[ "$arch_type" == "x86_64" ]]; then
-            arch_type="amd64"  # For Intel-based Mac
-        elif [[ "$arch_type" == "arm64" ]]; then
-            arch_type="arm64"  # For ARM-based Mac (Apple Silicon)
-        else
-            echo "Unsupported macOS architecture: $arch_type"
+    case "$os_type" in
+        darwin)
+            os_type="darwin"
+            arch_type="all" # Universal binary as per PR #235
+            ;;
+        linux)
+            os_type="linux"
+            case "$arch_type" in
+                x86_64) arch_type="amd64" ;;
+                aarch64|arm64) arch_type="arm64" ;;
+                *)
+                    echo "Unsupported Linux architecture: $arch_type"
+                    exit 1
+                    ;;
+            esac
+            ;;
+        *)
+            echo "Unsupported operating system: $os_type"
             exit 1
-        fi
-    elif [[ "$os_type" == "linux" ]]; then
-        arch_type="amd64"  # Assuming amd64 architecture for Linux
-    else
-        echo "Unsupported operating system: $os_type"
-        exit 1
+            ;;
+    esac
+
+    # Construction of possible URLs to handle original and PR #235 naming patterns
+    # URL 1: Clean name (PR #235) - runpodctl-linux-amd64.tar.gz
+    URL1="https://github.com/runpod/runpodctl/releases/download/${VERSION}/runpodctl-${os_type}-${arch_type}.tar.gz"
+    
+    # URL 2: Versioned name (Current Releases) - runpodctl-2.1.2-linux-amd64.tar.gz
+    # Removing 'v' from VERSION for the filename part
+    VER_STR=$(echo "$VERSION" | sed 's/^v//')
+    URL2="https://github.com/runpod/runpodctl/releases/download/${VERSION}/runpodctl-${VER_STR}-${os_type}-${arch_type}.tar.gz"
+
+    DOWNLOAD_URLS=("$URL1" "$URL2")
+}
+
+# ----------------------------- Homebrew Support ----------------------------- #
+try_brew_install() {
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        return 1
     fi
 
-    local version_without_v_prefix=${VERSION#v}
+    if ! command -v brew >/dev/null 2>&1; then
+        echo "Homebrew not detected. Falling back to binary installation..."
+        return 1
+    fi
 
-    DOWNLOAD_URL="https://github.com/runpod/runpodctl/releases/download/${VERSION}/runpodctl_${version_without_v_prefix}_${os_type}_${arch_type}.tar.gz"
+    echo "macOS detected. Attempting to install runpodctl via Homebrew..."
+    if install_with_brew "runpod/runpodctl/runpodctl"; then
+        echo "runpodctl installed successfully via Homebrew."
+        exit 0
+    fi
+
+    echo "Homebrew installation failed or was skipped. Falling back to binary..."
+    return 1
 }
 
 # ---------------------------- Download & Install ---------------------------- #
 download_and_install_cli() {
     local cli_archive_file_name="runpodctl.tar.gz"
-    if ! wget -q --progress=bar "$DOWNLOAD_URL" -O "$cli_archive_file_name"; then
-        echo "Failed to download $cli_archive_file_name."
-        exit 1
-    fi
-    local cli_file_name="runpodctl"
-    tar -xzf "$cli_archive_file_name" "$cli_file_name"
-    chmod +x "$cli_file_name"
-    if ! mv "$cli_file_name" /usr/local/bin/; then
-        echo "Failed to move $cli_file_name to /usr/local/bin/."
-        exit 1
-    fi
-    echo "runpodctl installed successfully."
-}
+    local success=false
 
+    for url in "${DOWNLOAD_URLS[@]}"; do
+        echo "Attempting to download runpodctl from $url ..."
+        if wget --progress=bar "$url" -O "$cli_archive_file_name"; then
+            success=true
+            break
+        fi
+    done
+
+    if [ "$success" = false ]; then
+        echo "Failed to download runpodctl from any provided URLs."
+        exit 1
+    fi
+
+    local cli_file_name="runpodctl"
+    tar -xzf "$cli_archive_file_name" "$cli_file_name" || { echo "Failed to extract $cli_file_name."; exit 1; }
+    # Clean up the downloaded archive after successful extraction
+    rm -f "$cli_archive_file_name"
+
+    chmod +x "$cli_file_name"
+
+    # Ensure the install directory is writable before attempting to move the binary
+    if [ ! -w "$INSTALL_DIR" ]; then
+        echo "Install directory '$INSTALL_DIR' is not writable. Please run with appropriate permissions or choose a different install directory."
+        # Clean up the extracted binary to avoid leaving stray files behind
+        rm -f "$cli_file_name"
+        exit 1
+    fi
+
+    if ! mv "$cli_file_name" "$INSTALL_DIR/"; then
+        echo "Failed to move $cli_file_name to $INSTALL_DIR/."
+        exit 1
+    fi
+    echo "runpodctl installed successfully to $INSTALL_DIR."
+}
 
 # ---------------------------------------------------------------------------- #
 #                                     Main                                     #
 # ---------------------------------------------------------------------------- #
 echo "Installing runpodctl..."
 
+# 1. Prioritize Homebrew on macOS
+if try_brew_install; then
+    exit 0
+fi
+
+# 2. Resilient Binary Installation (Universal Fallback)
+detect_install_dir
 check_root
 check_system_requirements
 fetch_latest_version

--- a/tests/integration_suite.sh
+++ b/tests/integration_suite.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# integration_suite.sh: Verifies installation and exercises full-feature integration matrix.
+# Reports: PASSED, FAILED, or EXPECTED_FAIL (for missing privileges/secrets).
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}Starting Unified Installation & Feature Matrix Tests...${NC}"
+
+# --- Dependencies ---
+for cmd in jq curl wget tar grep sed; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: Missing required command: $cmd"
+        exit 1
+    fi
+done
+
+# --- Helpers ---
+
+report_status() {
+    local name=$1
+    local status=$2
+    local msg=$3
+    case "$status" in
+        "PASSED") echo -e "  [${GREEN}PASSED${NC}] $name $msg" ;;
+        "FAILED") echo -e "  [${RED}FAILED${NC}] $name $msg"; return 1 ;;
+        "EXPECTED_FAIL") echo -e "  [${YELLOW}EXPECTED_FAIL${NC}] $name $msg" ;;
+    esac
+}
+
+run_step() {
+    local name=$1
+    local cmd=$2
+    local expect_fail_cond=$3
+    local max_attempts=${4:-1} # Default to 1 attempt unless specified
+    local target_output=$5 # Optional: specific file to capture output
+    local retry_delay=${6:-5} # Optional: delay between retries
+    local attempt=1
+    local output_file=${target_output:-$(mktemp)}
+
+    while [ $attempt -le $max_attempts ]; do
+        if eval "$cmd" > "$output_file" 2>&1; then
+            report_status "$name" "PASSED"
+            # Only remove if it's a generic temp file, not a requested capture
+            if [ -z "$target_output" ]; then rm "$output_file"; fi
+            return 0
+        fi
+
+        # Check for expected failure
+        if [[ -n "$expect_fail_cond" ]] && eval "$expect_fail_cond"; then
+            report_status "$name" "EXPECTED_FAIL" "(Environment limitation)"
+            if [ -z "$target_output" ]; then rm "$output_file"; fi
+            return 0
+        fi
+
+        if [ $attempt -lt $max_attempts ]; then
+            echo "  [RETRY] $name failed (Attempt $attempt/$max_attempts). Retrying in ${retry_delay}s..."
+            sleep "$retry_delay"
+            attempt=$((attempt + 1))
+        else
+            report_status "$name" "FAILED" "\nOutput:\n$(cat "$output_file")"
+            if [ -z "$target_output" ]; then rm "$output_file"; fi
+            return 1
+        fi
+    done
+}
+
+# --- Phase 1: Installation Validation ---
+echo -e "\n${GREEN}>> Phase 1: Installation Validation${NC}"
+
+if [ "$(id -u)" -eq 0 ]; then
+    echo "Environment: Root"
+    run_step "Root Install (/usr/local/bin)" "bash ./install.sh"
+    run_step "Binary Execution (version)" "runpodctl version"
+else
+    # Detect if the installer actually supports non-root
+    HAS_NONROOT_SUPPORT=$(grep "detect_install_dir" ./install.sh || true)
+    
+    mkdir -p "$HOME/.local/bin"
+    export PATH="$HOME/.local/bin:$PATH"
+    
+    run_step "User-space Install (~/.local/bin)" "bash ./install.sh" "[[ -z \"$HAS_NONROOT_SUPPORT\" ]]"
+    
+    if [[ -f "$HOME/.local/bin/runpodctl" ]]; then
+        run_step "Binary Execution (version)" "$HOME/.local/bin/runpodctl version"
+    fi
+fi
+
+# --- Phase 2: Feature Integration Audit (RunPod API) ---
+echo -e "\n${GREEN}>> Phase 2: Feature Integration Audit (RunPod API)${NC}"
+
+if [[ -z "$RUNPOD_API_KEY" ]]; then
+    report_status "API Integration" "EXPECTED_FAIL" "(RUNPOD_API_KEY missing)"
+else
+    # Determine binary path
+    RUNPODCTL="runpodctl"
+    if [ "$(id -u)" -ne 0 ] && [[ -f "$HOME/.local/bin/runpodctl" ]]; then
+        RUNPODCTL="$HOME/.local/bin/runpodctl"
+    fi
+
+    # 1. Pod Management Lifecycle
+    echo "Testing Pod Lifecycle (Template: bwf8egptou)..."
+    POD_NAME="ci-test-pod-$(date +%s)"
+    
+    create_out=$(mktemp)
+    if run_step "Pod Create" "$RUNPODCTL pod create --template-id bwf8egptou --compute-type CPU --name $POD_NAME" "" 3 "$create_out"; then
+        POD_ID=$(jq -r '.id' "$create_out" || true)
+        rm "$create_out"
+        
+        if [[ -n "$POD_ID" && "$POD_ID" != "null" ]]; then
+             echo "Waiting for Pod API propagation (5s)..."
+             sleep 5
+             # Propagation Retry: Retry every 10s for up to 2 minutes (12 attempts)
+             run_step "Pod List" "$RUNPODCTL pod list --output json | jq -e \"map(select(.id == \\\"$POD_ID\\\")) | length > 0\"" "" 12 "" 10
+             run_step "Pod Get" "$RUNPODCTL pod get $POD_ID" "" 3
+             run_step "Pod Update" "$RUNPODCTL pod update $POD_ID --name \"${POD_NAME}-updated\"" "" 3
+             run_step "Pod Stop" "$RUNPODCTL pod stop $POD_ID" "" 3
+             run_step "Pod Start" "$RUNPODCTL pod start $POD_ID" "" 3
+             
+             # Pod Data-Plane (Send/Receive)
+             echo "v1.14.15-ci-test" > ci-test-file.txt
+             CODE_OUT=$(mktemp)
+             echo "Starting Pod Send..."
+             $RUNPODCTL send ci-test-file.txt > "$CODE_OUT" 2>&1 &
+             SEND_PID=$!
+             
+             CROC_CODE=""
+             for i in {1..30}; do
+                 CROC_CODE=$(grep -oE '[a-z0-9-]+-[0-9]+$' "$CODE_OUT" | head -n 1 || true)
+                 if [[ -n "$CROC_CODE" ]]; then break; fi
+                 sleep 1
+             done
+             
+             if [[ -n "$CROC_CODE" ]]; then
+                 echo "Captured Croc Code: $CROC_CODE"
+                 run_step "Pod Receive" "$RUNPODCTL receive $CROC_CODE" "" 2
+             else
+                 report_status "Croc Code Extraction" "FAILED" "Could not capture generated code. Output:\n$(cat "$CODE_OUT")"
+             fi
+             kill $SEND_PID 2>/dev/null || true
+             rm -f "$CODE_OUT" ci-test-file.txt
+             
+             echo "Cleaning up Pod $POD_ID..."
+             $RUNPODCTL pod delete $POD_ID || true
+        else
+            report_status "Pod ID Extraction" "FAILED" "Could not extract valid ID"
+        fi
+    fi
+
+    # 2. Serverless Lifecycle
+    echo -e "\nTesting Serverless Lifecycle (Template: wvrr20un0l)..."
+    EP_NAME="ci-test-ep-$(date +%s)"
+    ep_out=$(mktemp)
+    if run_step "Serverless Create" "$RUNPODCTL serverless create --template-id wvrr20un0l --compute-type CPU --gpu-count 0 --workers-max 1 --name '$EP_NAME'" "" 3 "$ep_out"; then
+        EP_ID=$(jq -r '.id' "$ep_out" 2>/dev/null || true)
+        if [[ -z "$EP_ID" || "$EP_ID" == "null" ]]; then
+            echo "Error: Failed to extract Endpoint ID from create output:"
+            cat "$ep_out"
+            rm "$ep_out"
+            exit 1
+        fi
+        echo "Successfully created Endpoint: $EP_ID"
+        rm "$ep_out"
+
+        if [[ -n "$EP_ID" && "$EP_ID" != "null" ]]; then
+            echo "Waiting for Serverless endpoint $EP_ID to become available (Polling for up to 5m)..."
+            polling_attempt=1
+            max_polling=30 # 30 attempts * 10s = 5 minutes
+            ready=false
+            
+            while [ $polling_attempt -le $max_polling ]; do
+                if $RUNPODCTL serverless get $EP_ID > /dev/null 2>&1; then
+                    echo "  Endpoint $EP_ID found! Proceeding..."
+                    ready=true
+                    break
+                fi
+                echo "  [Poll $polling_attempt/$max_polling] Endpoint not found yet. Sleeping 10s..."
+                sleep 10
+                polling_attempt=$((polling_attempt + 1))
+            done
+
+            if [ "$ready" = false ]; then
+                report_status "Serverless Propagation" "FAILED" "Endpoint $EP_ID did not appear in the API within 5 minutes."
+                exit 1
+            fi
+
+            run_step "Serverless Get (Final Check)" "$RUNPODCTL serverless get $EP_ID" "" 3
+            # Propagation Retry: Retry every 10s for up to 2 minutes (12 attempts)
+            run_step "Serverless List" "$RUNPODCTL serverless list --output json | jq -e \"map(select(.id == \\\"$EP_ID\\\")) | length > 0\"" "" 12 "" 10
+            
+            # Propagation Retry: Retry every 10s for up to 2 minutes (12 attempts)
+            run_step "Serverless Update" "$RUNPODCTL serverless update $EP_ID --name \"${EP_NAME}-updated\"" "" 12 "" 10
+            
+            echo "Testing Serverless Job Submission..."
+            JOB_OUT=$(mktemp)
+            # Submission is usually fast if the endpoint 'Get' works
+            if run_step "Serverless Send (Job Submit)" "curl -s -X POST \"https://api.runpod.ai/v2/$EP_ID/run\" -H \"Content-Type: application/json\" -H \"Authorization: Bearer $RUNPOD_API_KEY\" -d '{\"input\": {\"test\": \"data\"}}'" "" 3 "$JOB_OUT"; then
+                JOB_ID=$(jq -r '.id' "$JOB_OUT")
+                if [[ -n "$JOB_ID" && "$JOB_ID" != "null" ]]; then
+                    run_step "Serverless Receive (Job Status)" "curl -s -X GET \"https://api.runpod.ai/v2/$EP_ID/status/$JOB_ID\" -H \"Authorization: Bearer $RUNPOD_API_KEY\" | jq -e '.status | test(\"COMPLETED|IN_PROGRESS|IN_QUEUE|PENDING\")'" "" 5
+                fi
+            fi
+            rm -f "$JOB_OUT"
+
+            # Propagation Retry: Retry every 10s for up to 2 minutes (12 attempts)
+            run_step "Serverless Delete" "$RUNPODCTL serverless delete $EP_ID" "" 12 "" 10
+        fi
+    fi
+fi
+
+echo -e "\n${GREEN}Unified Matrix Tests Completed.${NC}"


### PR DESCRIPTION
# PR: Feature: CI Testing

## Description
This PR implements a tiered testing strategy designed to independently test validation and integration.  

### Key Changes
- **Unified Integration Matrix**: Added `tests/integration_suite.sh` to report results as `PASSED`, `FAILED`, or `EXPECTED_FAIL`. This ensures that maintainers see clear "Feature Unavailable" signals for missing keys or root privileges instead of generic failures.
- **Full Lifecycle Audit**: The suite exercises the complete lifecycle of Pods and Serverless resources (Create -> List -> Get -> Update -> Stop -> Start -> Send/Receive -> Delete).
- **Gated CI Workflow**: Managed via `tests/integration_suite.sh` with separate root and non-root jobs.  Should the parallel non-root PR be accepted, builds will be tested for fitness in both root and non-root contexts.
- **Automatic Resource Cleanup**: Implemented a "Fail-Safe Kill Switch" in CI to ensure all created resources are removed even if tests fail or hang.
- **Safety Valve**: Though a RUNPOD_API_KEY is required for the integration tier, the build actions have been setup so that the key is not required for the validation tier (such as downstream PRs).  This allows validating that the project still builds and can still install and execute basic commands.  
- **TINY Images**: The CI images are based on alpine and the test images are based on Python:Alpine.  CI testing, spinning up the pods, and running the CLI tests is extremely fast owing to Runpod's architecture.

## Integration Notes
- Pending https://github.com/runpod/runpodctl/pull/235 made implementation and testing a bit precarious.  We decided to simply support both naming conventions for now so we could ship.  Pretty minor to eliminate the "old" naming format if that's a priority.

## Cost & Privacy
- Standardized on CPU-only compute and minimal templates to minimize CI expenses.
- The `RUNPOD_API_KEY` is protected against abuse by automatically reporting `EXPECTED_FAIL` on unapproved external forks.
<img width="1005" height="848" alt="image" src="https://github.com/user-attachments/assets/c15a76d5-d740-4cf5-b8cd-9d28b218ed54" />
<img width="1902" height="829" alt="image" src="https://github.com/user-attachments/assets/61cbe536-d332-42e1-89b3-622ab580ab73" />

There are Sourcery reviews and diagrams etc [here](https://github.com/FNGarvin/runpodctl/pull/4) that you can review if you like.  

Thanks,
FNG