### PR TITLE
fix: configure homebrew cask pr without fork

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,8 +56,13 @@ homebrew_casks:
       owner: runpod
       name: homebrew-runpodctl
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      branch: "runpodctl-{{ .Version }}"
       pull_request:
         enabled: true
+        base:
+          owner: runpod
+          name: homebrew-runpodctl
+          branch: main
     commit_author:
       name: runpod
       email: support@runpod.io


### PR DESCRIPTION
## Summary
- GoReleaser's `pull_request` mode was trying to fork `homebrew-runpodctl`, which fails with GitHub App tokens (apps can't fork repos)
- Fix: specify `branch` and `base` so GoReleaser pushes to a feature branch (`runpodctl-{version}`) on the **same** repo and creates a PR from there — no fork needed
- This respects the branch protection rules on `homebrew-runpodctl`

## What changed
```yaml
repository:
  owner: runpod
  name: homebrew-runpodctl
  token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
  branch: "runpodctl-{{ .Version }}"      # push to feature branch
  pull_request:
    enabled: true
    base:
      owner: runpod
      name: homebrew-runpodctl
      branch: main                         # PR targets main
```

## Test plan
- [ ] Merge this PR
- [ ] Tag a new release (v2.1.3)
- [ ] Verify GoReleaser creates a PR on `runpod/homebrew-runpodctl` (not a fork)