### PR TITLE
fix: trim agents.md to pitfalls and constraints only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,7 @@
-# CLAUDE.md — sharp edges & gotchas
+<!-- Do not edit or remove this section -->
+This document exists for non-obvious, error-prone shortcomings in the codebase, the model, or the tooling that an agent cannot figure out by reading the code alone. No architecture overviews, file trees, build commands, or standard behavior. When you encounter something that belongs here, first consider whether a code change could eliminate it and suggest that to the user. Only document it here if it can't be reasonably fixed.
+
+---
 
 ## pitfalls
 


### PR DESCRIPTION
## Summary
- Remove architecture descriptions, file trees, CLI usage tables, build commands, and standard patterns that are inferable from the codebase
- Keep only non-obvious gotchas, failure-prone decisions, and hidden constraints (pitfalls + constraints sections)
- Add two new pitfalls from operational experience: pod create must use graphql for `startSsh`, and rest-vs-graphql field shape mismatches
- 174 lines → 22 lines

## Test plan
- [ ] Verify CLAUDE.md symlink still resolves correctly
- [ ] Confirm all retained pitfalls are accurate against current code