### PR TITLE
fix: correct url in install script comment

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 # This script provides a unified approach to installing the RunPod CLI tool.
 #
 # Usage:
-#   wget -qO- cli.runpod.io | bash
+#   wget -qO- cli.runpod.net | bash
 #
 # Requirements:
 #   - Bash shell


### PR DESCRIPTION
## Summary
- The install script comment references `cli.runpod.io` which has no DNS record and doesn't resolve
- Changed to `cli.runpod.net` which is the actual working URL (used in README and codebase)

## One-liner
`cli.runpod.io` → `cli.runpod.net` in the usage comment on line 8 of `install.sh`