### PR TITLE
fix: switch homebrew from cask to formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ archives:
 release:
   prerelease: auto
 
-homebrew_casks:
+brews:
   - name: runpodctl
     homepage: "https://github.com/runpod/runpodctl"
     repository:
@@ -66,6 +66,8 @@ homebrew_casks:
     commit_author:
       name: runpod
       email: support@runpod.io
+    install: |
+      bin.install "runpodctl"
     ids: [default]
 
 checksum:


### PR DESCRIPTION
## Summary
- `homebrew_casks:` in GoReleaser writes to `Casks/runpodctl.rb`, but `brew install runpodctl` uses the **formula** at `runpodctl.rb` (repo root)
- The cask was being updated on every release (v2.1.1–v2.1.4) but users never saw it — `brew upgrade` stayed on v2.1.0
- Switches to `brews:` which updates the formula that users actually install
- This is what every major Go CLI tool does (gh, terraform, goreleaser, hugo)

## What changed
- `.goreleaser.yml`: `homebrew_casks:` → `brews:` with `install` block
- All other config (token, PR mode, commit author) stays the same

## Follow-up
- After verifying the formula updates work, the `Casks/` directory in `homebrew-runpodctl` can be cleaned up

## Test plan
- [ ] Merge this PR
- [ ] Tag a new release
- [ ] Verify GoReleaser creates a PR on `homebrew-runpodctl` updating `runpodctl.rb` (the formula, not the cask)
- [ ] Verify `brew update && brew upgrade runpodctl` picks up the new version