### PR TITLE
fix: update both homebrew formula and cask on release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,6 +52,7 @@ release:
 brews:
   - name: runpodctl
     homepage: "https://github.com/runpod/runpodctl"
+    description: "runpodctl is a CLI tool to manage your GPU pods on RunPod."
     repository:
       owner: runpod
       name: homebrew-runpodctl
@@ -63,6 +64,10 @@ brews:
           owner: runpod
           name: homebrew-runpodctl
           branch: main
+        body: |
+          update homebrew formula to [v{{ .Version }}](https://github.com/runpod/runpodctl/releases/tag/{{ .Tag }}).
+
+          {{ .ReleaseNotes }}
     commit_author:
       name: runpod
       email: support@runpod.io
@@ -73,6 +78,7 @@ brews:
 homebrew_casks:
   - name: runpodctl
     homepage: "https://github.com/runpod/runpodctl"
+    description: "runpodctl is a CLI tool to manage your GPU pods on RunPod."
     repository:
       owner: runpod
       name: homebrew-runpodctl
@@ -84,6 +90,10 @@ homebrew_casks:
           owner: runpod
           name: homebrew-runpodctl
           branch: main
+        body: |
+          update homebrew cask to [v{{ .Version }}](https://github.com/runpod/runpodctl/releases/tag/{{ .Tag }}).
+
+          {{ .ReleaseNotes }}
     commit_author:
       name: runpod
       email: support@runpod.io


### PR DESCRIPTION
## Summary
- Adds back the `homebrew_casks` section to `.goreleaser.yml` alongside the existing `brews` (formula) section
- On each release, GoReleaser will now open **two PRs** on `runpod/homebrew-runpodctl`: one for the formula (`runpodctl.rb` at root) and one for the cask (`Casks/runpodctl.rb`)
- Uses separate branch names (`runpodctl-<version>` for formula, `runpodctl-cask-<version>` for cask) to avoid conflicts

## Context
PR #248 switched from cask to formula, but users who installed via `brew install --cask` would stop getting updates. This ensures both installation methods stay in sync.

## Test plan
- [ ] Merge this PR and create a new release tag
- [ ] Verify two PRs are opened on `runpod/homebrew-runpodctl` — one updating the formula, one updating the cask
- [ ] Verify both PRs have correct versions and SHA256 hashes