### PR TITLE
fix: remove unsupported body field from goreleaser PR config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,10 +64,6 @@ brews:
           owner: runpod
           name: homebrew-runpodctl
           branch: main
-        body: |
-          update homebrew formula to [v{{ .Version }}](https://github.com/runpod/runpodctl/releases/tag/{{ .Tag }}).
-
-          {{ .ReleaseNotes }}
     commit_author:
       name: runpod
       email: support@runpod.io
@@ -90,10 +86,6 @@ homebrew_casks:
           owner: runpod
           name: homebrew-runpodctl
           branch: main
-        body: |
-          update homebrew cask to [v{{ .Version }}](https://github.com/runpod/runpodctl/releases/tag/{{ .Tag }}).
-
-          {{ .ReleaseNotes }}
     commit_author:
       name: runpod
       email: support@runpod.io


### PR DESCRIPTION
## Summary
- Removes the `body` field from `pull_request` config in `.goreleaser.yml`
- This field is not supported in GoReleaser v2.14 and caused the v2.1.6 release to fail with: `yaml: unmarshal errors: line 67: field body not found in type config.PullRequest`

## Test plan
- [ ] Merge and tag a new release (v2.1.6 needs to be re-released or v2.1.7)
- [ ] Verify GoReleaser creates two PRs on `homebrew-runpodctl`: one for formula, one for cask