### PR TITLE
fix: update command handles archived releases and universal binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Go 1.25.7
+      - name: Setup Go 1.25.8
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
       # You can test your matrix by printing the current Go version
       - name: Display Go version
         run: go version

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,17 @@ builds:
     ldflags:
       - -s -w -X main.Version={{ .Version }}-{{ .ShortCommit }}
 
+  # standalone per-arch binaries so older runpodctl versions can self-update
+  # (the old update command expects raw binaries named runpodctl-{os}-{arch})
+  - id: legacy
+    binary: runpodctl
+    goos: [darwin, linux, windows]
+    goarch: [amd64, arm64]
+    env: [CGO_ENABLED=0]
+    flags: [-mod=mod]
+    ldflags:
+      - -s -w -X main.Version={{ .Version }}-{{ .ShortCommit }}
+
   - id: linux_amd64_upx
     binary: runpodctl
     goos: [linux]
@@ -38,6 +49,12 @@ archives:
     format_overrides:
       - goos: windows
         formats: [zip]
+    name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
+
+  # raw binaries for backward compat with old runpodctl update command
+  - id: legacy
+    ids: [legacy]
+    formats: [binary]
     name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
 
   # UPX linux/amd64 artifact, also archived for internal Runpod use

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/mod/semver"
@@ -62,7 +66,6 @@ func GetJson(url string) (*GithubApiResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	// fmt.Println(string(body))
 	var result GithubApiResponse
 	err = json.Unmarshal(body, &result)
 	if err != nil {
@@ -70,6 +73,88 @@ func GetJson(url string) (*GithubApiResponse, error) {
 	}
 
 	return &result, nil
+}
+
+// assetName returns the expected release asset name for the current platform.
+// darwin uses a universal binary ("all"), others use the specific arch.
+// release assets are archives: .tar.gz for unix, .zip for windows.
+func assetName() string {
+	arch := runtime.GOARCH
+	if runtime.GOOS == "darwin" {
+		arch = "all"
+	}
+	ext := ".tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = ".zip"
+	}
+	return fmt.Sprintf("runpodctl-%s-%s%s", runtime.GOOS, arch, ext)
+}
+
+// extractBinaryFromTarGz extracts the "runpodctl" binary from a .tar.gz archive.
+func extractBinaryFromTarGz(archivePath, destPath string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if header.Typeflag == tar.TypeReg && filepath.Base(header.Name) == "runpodctl" {
+			out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+			if err != nil {
+				return err
+			}
+			defer out.Close()
+			if _, err := io.Copy(out, tr); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("runpodctl binary not found in archive")
+}
+
+// extractBinaryFromZip extracts the "runpodctl.exe" binary from a .zip archive.
+func extractBinaryFromZip(archivePath, destPath string) error {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		if strings.EqualFold(filepath.Base(f.Name), "runpodctl.exe") {
+			rc, err := f.Open()
+			if err != nil {
+				return err
+			}
+			defer rc.Close()
+			out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+			if err != nil {
+				return err
+			}
+			defer out.Close()
+			if _, err := io.Copy(out, rc); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("runpodctl.exe not found in archive")
 }
 
 var updateCmd = &cobra.Command{
@@ -84,58 +169,76 @@ var updateCmd = &cobra.Command{
 			fmt.Println("error fetching latest version info for runpodctl", err)
 			return
 		}
-		//find download link for current platform
 		latestVersion := apiResp.Version
-		if semver.Compare("v"+version, latestVersion) == -1 {
-			//version < latest
-			newBinaryName := fmt.Sprintf("runpodctl-%s-%s", runtime.GOOS, runtime.GOARCH)
-			foundNewBinary := false
-			var downloadLink string
-			for _, asset := range apiResp.Assets {
-				if asset.Name == newBinaryName {
-					foundNewBinary = true
-					downloadLink = asset.Url
-				}
-			}
-			if !foundNewBinary {
-				fmt.Printf("platform %s-%s not supported in latest version\n", runtime.GOOS, runtime.GOARCH)
-				return
-			}
-			ex, err := os.Executable()
-			if err != nil {
-				panic(err)
-			}
-			exPath := filepath.Dir(ex)
-			downloadPath := newBinaryName
-			destFilename := "runpodctl"
-			if runtime.GOOS == "windows" {
-				destFilename = "runpodctl.exe"
-			}
-			destPath := filepath.Join(exPath, destFilename)
-			if runtime.GOOS == "windows" {
-				fmt.Println("to get the newest version, run this command:")
-				fmt.Printf("wget https://github.com/runpod/runpodctl/releases/download/%s/%s -O runpodctl.exe\n", latestVersion, newBinaryName)
-			}
-			fmt.Printf("downloading runpodctl %s to %s\n", latestVersion, downloadPath)
-			file, err := DownloadFile(downloadLink, downloadPath)
-			defer file.Close()
-			if err != nil {
-				fmt.Println("error fetching the latest version of runpodctl", err)
-				return
-			}
-			//chmod +x
-			err = file.Chmod(0755)
-			if err != nil {
-				fmt.Println("error setting permissions on new binary", err)
-			}
-			fmt.Printf("moving %s to %s\n", downloadPath, destPath)
-			if runtime.GOOS == "windows" {
-				//if I do this, windows antivirus considers the program to be a trojan
-				// exec.Command("cmd", "/C", "rm", destPath, ";", "move", downloadPath, destPath).Run()
-			} else {
-				exec.Command("mv", downloadPath, destPath).Run() //need to run externally to current process because we're updating the running executable
-			}
+		if semver.Compare("v"+version, latestVersion) >= 0 {
+			fmt.Printf("runpodctl %s is already up to date\n", version)
+			return
 		}
 
+		// find download link for current platform
+		expectedAsset := assetName()
+		var downloadLink string
+		for _, asset := range apiResp.Assets {
+			if asset.Name == expectedAsset {
+				downloadLink = asset.Url
+				break
+			}
+		}
+		if downloadLink == "" {
+			fmt.Printf("platform %s-%s not supported in latest version\n", runtime.GOOS, runtime.GOARCH)
+			return
+		}
+
+		ex, err := os.Executable()
+		if err != nil {
+			fmt.Println("error finding current executable:", err)
+			return
+		}
+		exPath := filepath.Dir(ex)
+
+		destFilename := "runpodctl"
+		if runtime.GOOS == "windows" {
+			destFilename = "runpodctl.exe"
+		}
+		destPath := filepath.Join(exPath, destFilename)
+
+		// download archive to a temp file
+		tmpFile, err := os.CreateTemp("", "runpodctl-update-*")
+		if err != nil {
+			fmt.Println("error creating temp file:", err)
+			return
+		}
+		archivePath := tmpFile.Name()
+		tmpFile.Close()
+		defer os.Remove(archivePath)
+
+		fmt.Printf("downloading runpodctl %s\n", latestVersion)
+		file, err := DownloadFile(downloadLink, archivePath)
+		if err != nil {
+			fmt.Println("error fetching the latest version of runpodctl:", err)
+			return
+		}
+		file.Close()
+
+		// extract binary from archive to a temp location next to the destination
+		extractedPath := destPath + ".new"
+		defer os.Remove(extractedPath)
+
+		if runtime.GOOS == "windows" {
+			if err := extractBinaryFromZip(archivePath, extractedPath); err != nil {
+				fmt.Println("error extracting update:", err)
+				return
+			}
+			fmt.Println("to complete the update, run this command:")
+			fmt.Printf("move /Y \"%s\" \"%s\"\n", extractedPath, destPath)
+		} else {
+			if err := extractBinaryFromTarGz(archivePath, extractedPath); err != nil {
+				fmt.Println("error extracting update:", err)
+				return
+			}
+			fmt.Printf("installing runpodctl %s to %s\n", latestVersion, destPath)
+			// need to run externally to current process because we're updating the running executable
+			exec.Command("mv", extractedPath, destPath).Run()
+		}
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runpod/runpodctl
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/denisbrodbeck/machineid v1.0.1


### PR DESCRIPTION
## Summary

- **backward compat**: adds a `legacy` build in goreleaser that publishes raw per-arch binaries (`runpodctl-darwin-arm64`, `runpodctl-linux-amd64`, etc.) so old runpodctl versions can still self-update
- **new update logic**: the update command now correctly matches archived asset names (`.tar.gz`/`.zip`) and extracts the binary, and maps darwin to the universal binary (`darwin-all`)
- **ux**: adds an "already up to date" message instead of silently exiting

## Context

since v2.0.0, goreleaser only produces archives (`runpodctl-darwin-all.tar.gz`) and no longer publishes raw binaries. the old update command expected exact matches on `runpodctl-{os}-{arch}` which no longer existed, causing `platform darwin-arm64 not supported in latest version` for all users trying to self-update.

## Test plan

- [ ] verify goreleaser produces both archived and raw binary assets in a release
- [ ] test `runpodctl update` on darwin-arm64 with the new code (archive extraction path)
- [ ] test that an old runpodctl binary can update to this version via the raw binary assets
- [ ] test `runpodctl update` when already on latest shows "already up to date"