### PR TITLE
fix: bump release workflow go version to 1.25.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
## Summary

- bumps go version in `release.yml` from 1.25.7 to 1.25.8 to match `go.mod`
- without this, the goreleaser release build will fail with `version "go1.25.8" does not match go tool version "go1.25.7"` (same error we hit in CI)

## Context

the previous PR bumped `go.mod` and `ci.yml` to 1.25.8 but missed the release workflow.

## Test plan

- [ ] CI passes on this PR
- [ ] next tag push triggers a successful release build