### PR TITLE
feat: add --network-volume-id flag to pod/serverless create

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,4 +19,5 @@ This document exists for non-obvious, error-prone shortcomings in the codebase, 
 - all text output must be lowercase and concise.
 - default output format is json (for agent consumption); never change this default.
 - e2e tests cost real money — always clean up resources with `t.Cleanup`.
+- always e2e test cli changes before considering work done: build the binary, run the new/changed commands against the live api (`RUNPOD_API_KEY` is in the env), and clean up any created resources immediately after verifying the response. this is non-negotiable.
 - keep the runpodctl skill in sync: https://github.com/runpod/skills/tree/main/runpodctl — update it whenever commands, flags, or behavior change.

--- a/cmd/pod/create.go
+++ b/cmd/pod/create.go
@@ -53,6 +53,7 @@ var (
 	createCloudType         string
 	createDataCenterIDs     string
 	createSSH               bool
+	createNetworkVolumeID   string
 )
 
 func init() {
@@ -72,6 +73,7 @@ func init() {
 	createCmd.Flags().StringVar(&createCloudType, "cloud-type", "SECURE", "cloud type (SECURE or COMMUNITY)")
 	createCmd.Flags().StringVar(&createDataCenterIDs, "data-center-ids", "", "comma-separated list of data center ids")
 	createCmd.Flags().BoolVar(&createSSH, "ssh", true, "enable ssh on the pod")
+	createCmd.Flags().StringVar(&createNetworkVolumeID, "network-volume-id", "", "network volume id to attach")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -169,6 +171,10 @@ func createPodGraphQL(gpuTypeID, cloudType string, supportPublicIP bool) (map[st
 		VolumeMountPath:   createVolumeMountPath,
 	}
 
+	if createNetworkVolumeID != "" {
+		req.NetworkVolumeId = createNetworkVolumeID
+	}
+
 	if createPorts != "" {
 		req.Ports = createPorts
 	}
@@ -217,6 +223,10 @@ func createPodREST(computeType, gpuTypeID, cloudType string, supportPublicIP boo
 
 	if gpuTypeID != "" {
 		req.GpuTypeIDs = []string{gpuTypeID}
+	}
+
+	if createNetworkVolumeID != "" {
+		req.NetworkVolumeID = createNetworkVolumeID
 	}
 
 	if createPorts != "" {

--- a/cmd/serverless/create.go
+++ b/cmd/serverless/create.go
@@ -26,7 +26,8 @@ var (
 	createGpuCount      int
 	createWorkersMin    int
 	createWorkersMax    int
-	createDataCenterIDs string
+	createDataCenterIDs    string
+	createNetworkVolumeID  string
 )
 
 func init() {
@@ -38,6 +39,7 @@ func init() {
 	createCmd.Flags().IntVar(&createWorkersMin, "workers-min", 0, "minimum number of workers")
 	createCmd.Flags().IntVar(&createWorkersMax, "workers-max", 3, "maximum number of workers")
 	createCmd.Flags().StringVar(&createDataCenterIDs, "data-center-ids", "", "comma-separated list of data center ids")
+	createCmd.Flags().StringVar(&createNetworkVolumeID, "network-volume-id", "", "network volume id to attach")
 
 	createCmd.MarkFlagRequired("template-id") //nolint:errcheck
 }
@@ -64,6 +66,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 	if gpuTypeID != "" {
 		req.GpuTypeIDs = []string{gpuTypeID}
+	}
+
+	if createNetworkVolumeID != "" {
+		req.NetworkVolumeID = createNetworkVolumeID
 	}
 
 	if createDataCenterIDs != "" {

--- a/internal/api/endpoints.go
+++ b/internal/api/endpoints.go
@@ -38,7 +38,8 @@ type EndpointCreateRequest struct {
 	GpuCount      int      `json:"gpuCount,omitempty"`
 	WorkersMin    int      `json:"workersMin,omitempty"`
 	WorkersMax    int      `json:"workersMax,omitempty"`
-	DataCenterIDs []string `json:"dataCenterIds,omitempty"`
+	DataCenterIDs    []string `json:"dataCenterIds,omitempty"`
+	NetworkVolumeID  string   `json:"networkVolumeId,omitempty"`
 }
 
 // EndpointUpdateRequest is the request to update an endpoint

--- a/internal/api/graphql.go
+++ b/internal/api/graphql.go
@@ -234,6 +234,7 @@ type CreatePodGQLInput struct {
 	TemplateId        string       `json:"templateId,omitempty"`
 	VolumeInGb        int          `json:"volumeInGb,omitempty"`
 	VolumeMountPath   string       `json:"volumeMountPath,omitempty"`
+	NetworkVolumeId   string       `json:"networkVolumeId,omitempty"`
 }
 
 // CreatePod creates a pod via GraphQL (podFindAndDeployOnDemand)

--- a/internal/api/pods.go
+++ b/internal/api/pods.go
@@ -51,6 +51,7 @@ type PodCreateRequest struct {
 	Env               map[string]string `json:"env,omitempty"`
 	CloudType         string            `json:"cloudType,omitempty"`
 	DataCenterIDs     []string          `json:"dataCenterIds,omitempty"`
+	NetworkVolumeID   string            `json:"networkVolumeId,omitempty"`
 }
 
 // PodUpdateRequest is the request to update a pod


### PR DESCRIPTION
## Summary

- adds `--network-volume-id` flag to `pod create` (both GPU/GraphQL and CPU/REST paths)
- adds `--network-volume-id` flag to `serverless create` (REST)
- adds e2e testing constraint to AGENTS.md

Closes #256

## E2E verified

| path | result |
|------|--------|
| GPU pod (GraphQL) — `pod create --network-volume-id <id> --gpu-id "NVIDIA RTX A4500"` | created & booted in EU-RO-1 with network volume |
| CPU pod (REST) — `pod create --compute-type cpu --network-volume-id <id>` | created & booted in EU-RO-1 with network volume |
| serverless (REST) — `serverless create --network-volume-id <id>` | created, `networkVolumeId` confirmed in response |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./cmd/pod/... ./cmd/serverless/... ./internal/api/...` passes
- [x] `runpodctl pod create --help` shows `--network-volume-id`
- [x] `runpodctl serverless create --help` shows `--network-volume-id`
- [x] e2e: GPU pod with network volume (GraphQL path)
- [x] e2e: CPU pod with network volume (REST path)
- [x] e2e: serverless endpoint with network volume