### PR TITLE
fix: use flashBootType, not -fb

### DIFF
--- a/api/endpoint.go
+++ b/api/endpoint.go
@@ -32,6 +32,7 @@ type CreateEndpointInput struct {
 	ScalerValue     int    `json:"scalerValue"`
 	WorkersMin      int    `json:"workersMin"`
 	WorkersMax      int    `json:"workersMax"`
+	FlashBootType   string `json:"flashBootType"`
 }
 
 // there are many more fields in the result of the query but I just care about these for CLI port

--- a/cmd/project/functions.go
+++ b/cmd/project/functions.go
@@ -578,7 +578,7 @@ func deployProject(networkVolumeId string) (endpointId string, err error) {
 	minWorkers := 0
 	maxWorkers := 3
 	flashboot := true
-	flashbootSuffix := " -fb"
+	flashBootType := "FLASHBOOT"
 	idleTimeout := 5
 	endpointConfig, ok := config.Get("endpoint").(*toml.Tree)
 	if ok {
@@ -592,7 +592,7 @@ func deployProject(networkVolumeId string) (endpointId string, err error) {
 			flashboot = fb
 		}
 		if !flashboot {
-			flashbootSuffix = ""
+			flashBootType = "OFF"
 		}
 		if idle, ok := endpointConfig.Get("idle_timeout").(int64); ok {
 			idleTimeout = int(idle)
@@ -600,7 +600,7 @@ func deployProject(networkVolumeId string) (endpointId string, err error) {
 	}
 	if err != nil {
 		deployedEndpointId, err = api.CreateEndpoint(&api.CreateEndpointInput{
-			Name:            fmt.Sprintf("%s-endpoint-%s%s", projectName, projectId, flashbootSuffix),
+			Name:            fmt.Sprintf("%s-endpoint-%s", projectName, projectId),
 			TemplateId:      projectEndpointTemplateId,
 			NetworkVolumeId: networkVolumeId,
 			GpuIds:          "AMPERE_16",
@@ -609,6 +609,7 @@ func deployProject(networkVolumeId string) (endpointId string, err error) {
 			ScalerValue:     4,
 			WorkersMin:      minWorkers,
 			WorkersMax:      maxWorkers,
+			FlashBootType:   flashBootType,
 		})
 		if err != nil {
 			fmt.Println("error making endpoint")


### PR DESCRIPTION
indicate an endpoint is flashboot enabled with flashBootType instead of appending -fb to the name
