### PR TITLE
fix: rename default ssh key to runpodctl-ssh-key

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -65,7 +65,7 @@ func getOrCreateSSHKey() ([]byte, error) {
 
 	if publicKey == nil {
 		fmt.Println("No existing local SSH key found, generating a new one.")
-		publicKey, err = ssh.GenerateSSHKeyPair("RunPod-Key-Go")
+		publicKey, err = ssh.GenerateSSHKeyPair(ssh.DefaultKeyName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate SSH key: %w", err)
 		}

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -179,7 +179,7 @@ func checkSSHKey() checkResult {
 	// generate if not found
 	if publicKey == nil {
 		fmt.Fprintln(os.Stderr, "generating ssh key...")
-		publicKey, err = ssh.GenerateSSHKeyPair("RunPod-Key-Go")
+		publicKey, err = ssh.GenerateSSHKeyPair(ssh.DefaultKeyName)
 		if err != nil {
 			result.Status = "fail"
 			result.Error = fmt.Sprintf("failed to generate ssh key: %v", err)

--- a/cmd/project/ssh.go
+++ b/cmd/project/ssh.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/runpod/runpodctl/api"
+	sshpkg "github.com/runpod/runpodctl/cmd/ssh"
 
 	"github.com/fatih/color"
 	"golang.org/x/crypto/ssh"
@@ -254,12 +255,11 @@ func scanAndPrint(pipe io.Reader, color *color.Color, podID string, showPodIdPre
 }
 
 func PodSSHConnection(podId string) (*SSHConnection, error) {
-	homeDir, err := os.UserHomeDir()
+	sshKeyPath, err := sshpkg.ResolvePrivateKeyPath()
 	if err != nil {
-		return nil, fmt.Errorf("getting user home directory: %w", err)
+		return nil, fmt.Errorf("resolving ssh key path: %w", err)
 	}
 
-	sshKeyPath := filepath.Join(homeDir, ".runpod", "ssh", "RunPod-Key-Go")
 	privateKeyBytes, err := os.ReadFile(sshKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading private SSH key from %s: %w", sshKeyPath, err)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -190,12 +190,12 @@ func confirmAddKey() bool {
 }
 
 func promptKeyName() string {
-	fmt.Fprint(os.Stderr, "please enter a name for this key (default 'RunPod-Key-Go'): ")
+	fmt.Fprintf(os.Stderr, "please enter a name for this key (default '%s'): ", ssh.DefaultKeyName)
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	keyName := scanner.Text()
 	if keyName == "" {
-		return "RunPod-Key-Go"
+		return ssh.DefaultKeyName
 	}
 	return strings.ReplaceAll(keyName, " ", "-")
 }

--- a/cmd/ssh/commands.go
+++ b/cmd/ssh/commands.go
@@ -99,12 +99,12 @@ func confirmAddKey() bool {
 }
 
 func promptKeyName() string {
-	fmt.Print("Please enter a name for this key (default 'RunPod-Key'): ")
+	fmt.Printf("Please enter a name for this key (default '%s'): ", DefaultKeyName)
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	keyName := scanner.Text()
 	if keyName == "" {
-		return "RunPod-Key"
+		return DefaultKeyName
 	}
 	return strings.ReplaceAll(keyName, " ", "-")
 }

--- a/cmd/ssh/functions.go
+++ b/cmd/ssh/functions.go
@@ -13,6 +13,13 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+const (
+	// DefaultKeyName is the name used for newly generated ssh keys.
+	DefaultKeyName = "runpodctl-ssh-key"
+	// LegacyKeyName is the previous default, kept for backwards compatibility.
+	LegacyKeyName = "RunPod-Key-Go"
+)
+
 // GenerateSSHKeyPair generates an RSA key pair and saves the private key to a file in the user's home directory.
 func GenerateSSHKeyPair(keyName string) ([]byte, error) {
 	homeDir, err := os.UserHomeDir()
@@ -70,21 +77,51 @@ func GetLocalSSHKey() ([]byte, error) {
 		return nil, fmt.Errorf("failed to get user home directory: %w", err)
 	}
 
-	keyPath := filepath.Join(homeDir, ".runpod", "ssh", "RunPod-Key-Go.pub")
+	sshDir := filepath.Join(homeDir, ".runpod", "ssh")
 
-	publicKey, err := os.ReadFile(keyPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil // No existing key found
+	// check new name first, then fall back to legacy name
+	for _, name := range []string{DefaultKeyName, LegacyKeyName} {
+		keyPath := filepath.Join(sshDir, name+".pub")
+		publicKey, err := os.ReadFile(keyPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read existing public key: %w", err)
 		}
-		return nil, fmt.Errorf("failed to read existing public key: %w", err)
+
+		// Validate the key format
+		_, _, _, _, err = ssh.ParseAuthorizedKey(publicKey)
+		if err != nil {
+			return nil, fmt.Errorf("invalid public key format: %w", err)
+		}
+
+		return publicKey, nil
 	}
 
-	// Validate the key format
-	_, _, _, _, err = ssh.ParseAuthorizedKey(publicKey)
+	return nil, nil // no existing key found
+}
+
+// ResolvePrivateKeyPath returns the path to the private key, checking the
+// current default name first and falling back to the legacy name.
+// If neither exists on disk the new default path is returned.
+func ResolvePrivateKeyPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("invalid public key format: %w", err)
+		return "", fmt.Errorf("failed to get user home directory: %w", err)
 	}
 
-	return publicKey, nil
+	sshDir := filepath.Join(homeDir, ".runpod", "ssh")
+
+	newPath := filepath.Join(sshDir, DefaultKeyName)
+	if _, err := os.Stat(newPath); err == nil {
+		return newPath, nil
+	}
+
+	legacyPath := filepath.Join(sshDir, LegacyKeyName)
+	if _, err := os.Stat(legacyPath); err == nil {
+		return legacyPath, nil
+	}
+
+	return newPath, nil // default even if not yet created
 }

--- a/internal/sshconnect/sshconnect.go
+++ b/internal/sshconnect/sshconnect.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	defaultKeyName = "RunPod-Key-Go"
+	defaultKeyName = "runpodctl-ssh-key"
+	legacyKeyName  = "RunPod-Key-Go"
 )
 
 // KeyInfo describes the local ssh key and account match status.
@@ -122,11 +123,18 @@ func defaultKeyPath() (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	keyPath := filepath.Join(homeDir, ".runpod", "ssh", defaultKeyName)
-	if _, err := os.Stat(keyPath); err == nil {
-		return keyPath, true
+	sshDir := filepath.Join(homeDir, ".runpod", "ssh")
+
+	// check new name first, then fall back to legacy name
+	newPath := filepath.Join(sshDir, defaultKeyName)
+	if _, err := os.Stat(newPath); err == nil {
+		return newPath, true
 	}
-	return keyPath, false
+	legacyPath := filepath.Join(sshDir, legacyKeyName)
+	if _, err := os.Stat(legacyPath); err == nil {
+		return legacyPath, true
+	}
+	return newPath, false
 }
 
 func readPublicKeyFingerprint(path string) (string, error) {


### PR DESCRIPTION
## Summary
- renames the default ssh key from `RunPod-Key-Go` (and `RunPod-Key`) to `runpodctl-ssh-key`
- all code paths that read keys from disk check the new name first and fall back to the legacy `RunPod-Key-Go` name, so existing users are not affected
- affected files: `cmd/ssh/functions.go`, `cmd/doctor/doctor.go`, `cmd/config/config.go`, `cmd/ssh.go`, `cmd/ssh/commands.go`, `cmd/project/ssh.go`, `internal/sshconnect/sshconnect.go`

## How backwards compatibility works
every place that resolves a key path (public or private) now checks for `~/.runpod/ssh/runpodctl-ssh-key` first, then falls back to `~/.runpod/ssh/RunPod-Key-Go`. new keys are always generated with the new name.

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./... -short` — all pass
- [x] built binary, ran `runpodctl doctor` against live api — finds existing legacy key and passes all checks
- [ ] fresh install (no `~/.runpod/ssh/` dir) generates key as `runpodctl-ssh-key`