### PR TITLE
fix: use model version uuid for Model Repo upload batches

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -38,6 +38,7 @@ type ModelUser struct {
 
 // ModelVersion represents a specific version of a model stored in the repository.
 type ModelVersion struct {
+	UUID        string                 `json:"uuid,omitempty"`
 	Hash        string                 `json:"hash,omitempty"`
 	VersionHash string                 `json:"versionHash,omitempty"`
 	Status      string                 `json:"status,omitempty"`
@@ -199,6 +200,7 @@ type RemoveModelInput struct {
 // CreateModelRepoUploadInput defines the payload used to start a multipart upload for a model version.
 type CreateModelRepoUploadInput struct {
 	Name                string                 `json:"name,omitempty"`
+	ModelVersionUUID    string                 `json:"modelVersionUuid,omitempty"`
 	FileName            string                 `json:"fileName"`
 	FileSizeBytes       string                 `json:"fileSizeBytes"`
 	PartSizeBytes       string                 `json:"partSizeBytes,omitempty"`
@@ -647,6 +649,7 @@ func CreateModelRepoUpload(input *CreateModelRepoUploadInput) (*ModelRepoMutatio
 	addString("contentType", input.ContentType)
 	addString("credentialType", input.CredentialType)
 	addString("credentialReference", input.CredentialReference)
+	addString("modelVersionUuid", input.ModelVersionUUID)
 
 	if len(input.Metadata) > 0 {
 		payload["metadata"] = input.Metadata
@@ -688,6 +691,7 @@ func CreateModelRepoUpload(input *CreateModelRepoUploadInput) (*ModelRepoMutatio
                                         updatedAt
                                 }
                                 version {
+                                        uuid
                                         hash
                                         status
                                         metadata

--- a/cmd/model/addModelToRepo.go
+++ b/cmd/model/addModelToRepo.go
@@ -90,6 +90,11 @@ type modelFile struct {
 
 // TODO: replace the manual completion call with github.com/aws/aws-sdk-go-v2/service/s3's
 // CompleteMultipartUpload to rely on the SDK for payload formatting and signing logic.
+var (
+	createModelRepoUpload   = api.CreateModelRepoUpload
+	completeModelRepoUpload = api.CompleteModelRepoUpload
+	completeModelUploadFile = completeModelUpload
+)
 
 var addCmd = &cobra.Command{
 	Use:   "add",
@@ -284,20 +289,31 @@ func collectModelFiles(dir string) ([]modelFile, error) {
 }
 
 func uploadModelFiles(files []modelFile, baseInput *api.CreateModelRepoUploadInput) error {
-	for _, file := range files {
+	var modelVersionUUID string
+
+	for i, file := range files {
 		input := *baseInput
 		input.FileName = file.RelativePath
 		input.FileSizeBytes = strconv.FormatInt(file.Size, 10)
+		input.ModelVersionUUID = modelVersionUUID
 
-		result, err := api.CreateModelRepoUpload(&input)
+		result, err := createModelRepoUpload(&input)
 		if err != nil {
 			return fmt.Errorf("create upload for %s: %w", file.RelativePath, err)
 		}
 		if result.Upload == nil {
 			return fmt.Errorf("upload response missing upload session details for %s", file.RelativePath)
 		}
+		if modelVersionUUID == "" {
+			if result.Version != nil {
+				modelVersionUUID = strings.TrimSpace(result.Version.UUID)
+			}
+			if modelVersionUUID == "" && i < len(files)-1 {
+				return fmt.Errorf("upload response missing model version uuid for %s", file.RelativePath)
+			}
+		}
 
-		if err = completeModelUpload(result.Upload, file.AbsolutePath); err != nil {
+		if err = completeModelUploadFile(result.Upload, file.AbsolutePath); err != nil {
 			return fmt.Errorf("upload %s: %w", file.RelativePath, err)
 		}
 
@@ -305,7 +321,7 @@ func uploadModelFiles(files []modelFile, baseInput *api.CreateModelRepoUploadInp
 			return fmt.Errorf("upload %s: missing session identifier for completion", file.RelativePath)
 		}
 
-		completion, err := api.CompleteModelRepoUpload(result.Upload.SessionID)
+		completion, err := completeModelRepoUpload(result.Upload.SessionID)
 		if err != nil {
 			return fmt.Errorf("complete upload session for %s: %w", file.RelativePath, err)
 		}

--- a/cmd/model/addModelToRepo_timeout_test.go
+++ b/cmd/model/addModelToRepo_timeout_test.go
@@ -74,3 +74,62 @@ func TestSetModelGraphQLTimeoutSkipsWhenInheritedFlagChanged(t *testing.T) {
 		t.Fatalf("expected graphql timeout to remain unset, got %s", got)
 	}
 }
+
+func TestUploadModelFilesUsesModelVersionUUIDAfterFirstFile(t *testing.T) {
+	oldCreateModelRepoUpload := createModelRepoUpload
+	oldCompleteModelUploadFile := completeModelUploadFile
+	oldCompleteModelRepoUpload := completeModelRepoUpload
+	t.Cleanup(func() {
+		createModelRepoUpload = oldCreateModelRepoUpload
+		completeModelUploadFile = oldCompleteModelUploadFile
+		completeModelRepoUpload = oldCompleteModelRepoUpload
+	})
+
+	files := []modelFile{
+		{AbsolutePath: "/tmp/a.bin", RelativePath: "a.bin", Size: 1},
+		{AbsolutePath: "/tmp/b.bin", RelativePath: "b.bin", Size: 2},
+		{AbsolutePath: "/tmp/c.bin", RelativePath: "c.bin", Size: 3},
+	}
+
+	var calls []api.CreateModelRepoUploadInput
+	createModelRepoUpload = func(input *api.CreateModelRepoUploadInput) (*api.ModelRepoMutationResult, error) {
+		calls = append(calls, *input)
+		return &api.ModelRepoMutationResult{
+			Success: true,
+			Version: &api.ModelVersion{
+				UUID: "version-uuid",
+				Hash: "version-hash",
+			},
+			Upload: &api.ModelRepoUpload{
+				SessionID: "session-" + input.FileName,
+				Key:       "key-" + input.FileName,
+			},
+		}, nil
+	}
+	completeModelUploadFile = func(upload *api.ModelRepoUpload, artifactPath string) error {
+		return nil
+	}
+	completeModelRepoUpload = func(sessionID string) (*api.CompleteModelRepoUploadResult, error) {
+		return &api.CompleteModelRepoUploadResult{
+			SessionID: sessionID,
+			Status:    "completed",
+		}, nil
+	}
+
+	err := uploadModelFiles(files, &api.CreateModelRepoUploadInput{Name: "test-model"})
+	if err != nil {
+		t.Fatalf("uploadModelFiles returned error: %v", err)
+	}
+
+	if len(calls) != len(files) {
+		t.Fatalf("expected %d createModelRepoUpload calls, got %d", len(files), len(calls))
+	}
+	if calls[0].ModelVersionUUID != "" {
+		t.Fatalf("expected first upload call to omit modelVersionUuid, got %q", calls[0].ModelVersionUUID)
+	}
+	for i := 1; i < len(calls); i++ {
+		if calls[i].ModelVersionUUID != "version-uuid" {
+			t.Fatalf("expected call %d to use modelVersionUuid %q, got %q", i, "version-uuid", calls[i].ModelVersionUUID)
+		}
+	}
+}


### PR DESCRIPTION
# use model version uuid for Model Repo upload batches

Request version uuid from createModelRepoUpload and reuse it as the batch handle for subsequent file uploads. Keep hash as response metadata only, and add coverage for multi-file upload grouping.

