### PR TITLE
feat: add runpodctl skill sync checker

### DIFF
--- a/docs/skill-sync.md
+++ b/docs/skill-sync.md
@@ -1,0 +1,18 @@
+# skill sync check
+
+`tools/skill-sync` validates that the Runpod agent skill stays aligned with the public `runpodctl` command surface without turning `SKILL.md` into a full flag reference.
+
+The check verifies that:
+
+- `SKILL.md` says live `runpodctl --help` output is authoritative for exact flags.
+- Public top-level commands are mentioned.
+- Fenced `runpodctl ...` examples use valid public command paths.
+- Hidden or deprecated commands are not recommended in examples.
+
+Run it from the `runpodctl` repo with a sibling checkout of `runpod/skills`:
+
+```bash
+go run ./tools/skill-sync --skill ../skills/runpodctl/SKILL.md
+```
+
+This is a local check only. Release automation can call this tool later once the checker behavior is stable.

--- a/tools/skill-sync/main.go
+++ b/tools/skill-sync/main.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/runpod/runpodctl/cmd"
+	"github.com/spf13/cobra"
+)
+
+type checkIssue struct {
+	Kind    string
+	Message string
+}
+
+func main() {
+	skillPath := flag.String("skill", "../skills/runpodctl/SKILL.md", "path to the runpodctl SKILL.md file")
+	flag.Parse()
+
+	content, err := os.ReadFile(*skillPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "skill sync check failed: read skill: %v\n", err)
+		os.Exit(1)
+	}
+
+	issues := checkSkill(cmd.GetRootCmd(), string(content))
+	if len(issues) > 0 {
+		fmt.Fprintln(os.Stderr, "skill sync check failed:")
+		for _, issue := range issues {
+			fmt.Fprintf(os.Stderr, "- [%s] %s\n", issue.Kind, issue.Message)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Println("skill sync check passed")
+}
+
+func checkSkill(root *cobra.Command, skill string) []checkIssue {
+	var issues []checkIssue
+
+	if !hasLiveHelpGuidance(skill) {
+		issues = append(issues, checkIssue{
+			Kind:    "live-help",
+			Message: "SKILL.md must say live runpodctl --help output is authoritative for exact flags",
+		})
+	}
+
+	for _, command := range publicTopLevelCommands(root) {
+		if !mentionsCommand(skill, command) {
+			issues = append(issues, checkIssue{
+				Kind:    "missing-command",
+				Message: fmt.Sprintf("public top-level command %q is not mentioned", command),
+			})
+		}
+	}
+
+	for _, example := range runpodctlExamples(skill) {
+		result := resolveExample(root, example)
+		switch {
+		case result.Placeholder:
+			continue
+		case !result.Found:
+			issues = append(issues, checkIssue{
+				Kind:    "invalid-example",
+				Message: fmt.Sprintf("example does not reference a valid command path: %q", example),
+			})
+		case result.Hidden:
+			issues = append(issues, checkIssue{
+				Kind:    "hidden-command",
+				Message: fmt.Sprintf("example recommends hidden command %q: %q", strings.Join(result.Path, " "), example),
+			})
+		case result.Deprecated:
+			issues = append(issues, checkIssue{
+				Kind:    "deprecated-command",
+				Message: fmt.Sprintf("example recommends deprecated command %q: %q", strings.Join(result.Path, " "), example),
+			})
+		}
+	}
+
+	return issues
+}
+
+func hasLiveHelpGuidance(skill string) bool {
+	lower := strings.ToLower(skill)
+	return strings.Contains(lower, "authoritative") &&
+		strings.Contains(lower, "exact flags") &&
+		strings.Contains(lower, "runpodctl --help") &&
+		strings.Contains(lower, "runpodctl <resource> <action> --help")
+}
+
+func publicTopLevelCommands(root *cobra.Command) []string {
+	var commands []string
+	for _, child := range root.Commands() {
+		if child.Hidden || child.Deprecated != "" {
+			continue
+		}
+		name := commandName(child)
+		if name == "" {
+			continue
+		}
+		commands = append(commands, name)
+	}
+	sort.Strings(commands)
+	return commands
+}
+
+func mentionsCommand(skill, command string) bool {
+	pattern := regexp.MustCompile(`(?m)(^|[^[:alnum:]_-])runpodctl\s+` + regexp.QuoteMeta(command) + `([^[:alnum:]_-]|$)`)
+	if pattern.MatchString(skill) {
+		return true
+	}
+
+	heading := regexp.MustCompile(`(?mi)^#{2,4}\s+` + regexp.QuoteMeta(command) + `(\s|\(|$)`)
+	return heading.MatchString(skill)
+}
+
+func runpodctlExamples(skill string) []string {
+	var examples []string
+	inFence := false
+
+	for _, rawLine := range strings.Split(skill, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if strings.HasPrefix(line, "```") {
+			inFence = !inFence
+			continue
+		}
+		if !inFence {
+			continue
+		}
+
+		line = strings.TrimPrefix(line, "$ ")
+		if !strings.HasPrefix(line, "runpodctl ") {
+			continue
+		}
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			line = strings.TrimSpace(line[:idx])
+		}
+		if line != "" {
+			examples = append(examples, line)
+		}
+	}
+
+	return examples
+}
+
+type exampleResolution struct {
+	Found       bool
+	Hidden      bool
+	Deprecated  bool
+	Placeholder bool
+	Path        []string
+}
+
+func resolveExample(root *cobra.Command, example string) exampleResolution {
+	fields := strings.Fields(example)
+	if len(fields) < 2 || fields[0] != "runpodctl" {
+		return exampleResolution{Placeholder: true}
+	}
+	if strings.HasPrefix(fields[1], "-") {
+		return exampleResolution{Placeholder: true}
+	}
+
+	current := root
+	var path []string
+	for _, token := range fields[1:] {
+		if strings.HasPrefix(token, "-") {
+			break
+		}
+		if strings.ContainsAny(token, "<>[]") {
+			if len(path) == 0 {
+				return exampleResolution{Placeholder: true}
+			}
+			break
+		}
+
+		child := findChild(current, token)
+		if child == nil {
+			if hasPublicChildren(current) {
+				return exampleResolution{Found: false, Path: path}
+			}
+			break
+		}
+		current = child
+		path = append(path, commandName(child))
+	}
+
+	if len(path) == 0 {
+		return exampleResolution{Found: false}
+	}
+
+	return exampleResolution{
+		Found:      true,
+		Hidden:     hasHiddenCommand(root, path),
+		Deprecated: hasDeprecatedCommand(root, path),
+		Path:       path,
+	}
+}
+
+func hasPublicChildren(command *cobra.Command) bool {
+	for _, child := range command.Commands() {
+		if !child.Hidden && child.Deprecated == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func findChild(parent *cobra.Command, token string) *cobra.Command {
+	for _, child := range parent.Commands() {
+		if commandName(child) == token {
+			return child
+		}
+		for _, alias := range child.Aliases {
+			if alias == token {
+				return child
+			}
+		}
+	}
+	return nil
+}
+
+func hasHiddenCommand(root *cobra.Command, path []string) bool {
+	current := root
+	for _, token := range path {
+		current = findChild(current, token)
+		if current == nil {
+			return false
+		}
+		if current.Hidden {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDeprecatedCommand(root *cobra.Command, path []string) bool {
+	current := root
+	for _, token := range path {
+		current = findChild(current, token)
+		if current == nil {
+			return false
+		}
+		if current.Deprecated != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func commandName(command *cobra.Command) string {
+	if command == nil {
+		return ""
+	}
+	fields := strings.Fields(command.Use)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}

--- a/tools/skill-sync/main_test.go
+++ b/tools/skill-sync/main_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRunpodctlExamples(t *testing.T) {
+	skill := `
+runpodctl pod list
+
+` + "```bash" + `
+# comment
+runpodctl pod list --all # inline comment
+$ runpodctl serverless create --hub-id abc
+curl https://example.com
+` + "```" + `
+`
+
+	examples := runpodctlExamples(skill)
+	expected := []string{
+		"runpodctl pod list --all",
+		"runpodctl serverless create --hub-id abc",
+	}
+
+	if strings.Join(examples, "\n") != strings.Join(expected, "\n") {
+		t.Fatalf("unexpected examples:\n%v", examples)
+	}
+}
+
+func TestCheckSkill(t *testing.T) {
+	root := testRoot()
+	skill := `
+live runpodctl --help output is authoritative for exact flags.
+use runpodctl <resource> <action> --help before using unfamiliar commands.
+
+## Commands
+runpodctl pod
+runpodctl serverless
+runpodctl help
+
+` + "```bash" + `
+runpodctl pod list
+runpodctl serverless create --hub-id abc
+` + "```" + `
+`
+
+	issues := checkSkill(root, skill)
+	if len(issues) > 0 {
+		t.Fatalf("expected no issues, got %+v", issues)
+	}
+}
+
+func TestCheckSkillReportsInvalidAndDeprecatedExamples(t *testing.T) {
+	root := testRoot()
+	skill := `
+live runpodctl --help output is authoritative for exact flags.
+use runpodctl <resource> <action> --help before using unfamiliar commands.
+
+runpodctl pod
+runpodctl serverless
+runpodctl help
+
+` + "```bash" + `
+runpodctl pod missing
+runpodctl old
+` + "```" + `
+`
+
+	issues := checkSkill(root, skill)
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %+v", issues)
+	}
+	if issues[0].Kind != "invalid-example" {
+		t.Fatalf("expected invalid-example first, got %+v", issues)
+	}
+	if issues[1].Kind != "deprecated-command" {
+		t.Fatalf("expected deprecated-command second, got %+v", issues)
+	}
+}
+
+func TestCheckSkillReportsHiddenExampleWithPlaceholderArg(t *testing.T) {
+	root := testRoot()
+	skill := `
+live runpodctl --help output is authoritative for exact flags.
+use runpodctl <resource> <action> --help before using unfamiliar commands.
+
+runpodctl pod
+runpodctl serverless
+runpodctl help
+
+` + "```bash" + `
+runpodctl hidden <id>
+` + "```" + `
+`
+
+	issues := checkSkill(root, skill)
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %+v", issues)
+	}
+	if issues[0].Kind != "hidden-command" {
+		t.Fatalf("expected hidden-command, got %+v", issues)
+	}
+}
+
+func testRoot() *cobra.Command {
+	root := &cobra.Command{Use: "runpodctl"}
+	pod := &cobra.Command{Use: "pod"}
+	pod.AddCommand(&cobra.Command{Use: "list"})
+	serverless := &cobra.Command{Use: "serverless", Aliases: []string{"sls"}}
+	serverless.AddCommand(&cobra.Command{Use: "create"})
+	root.AddCommand(pod, serverless)
+	root.SetHelpCommand(&cobra.Command{Use: "help"})
+	root.AddCommand(&cobra.Command{Use: "old", Deprecated: "use pod instead"})
+	root.AddCommand(&cobra.Command{Use: "hidden", Hidden: true})
+	return root
+}


### PR DESCRIPTION
## Summary
- add a local skill-sync checker for validating the runpodctl skill
- verify live-help guidance, public command coverage, valid examples, and hidden/deprecated command avoidance
- document how to run the checker against a sibling runpod/skills checkout

## Paired PR
- Paired skills update: https://github.com/runpod/skills/pull/18

## Test plan
- go test ./tools/skill-sync
- go run ./tools/skill-sync --skill ../skills/runpodctl/SKILL.md
- go test ./...