### PR TITLE
feat: CE-1584: Show model version hash in model list

### DIFF
--- a/cmd/model/getModels.go
+++ b/cmd/model/getModels.go
@@ -76,12 +76,13 @@ func runModelList(cmd *cobra.Command, args []string) {
 func displayModels(models []*api.Model) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
 
-	fmt.Fprintln(w, "ID\tProvider\tName\tOwner\tStatus\tCreated At\tUpdated At")
-	fmt.Fprintln(w, "--\t--------\t----\t-----\t------\t----------\t----------")
+	fmt.Fprintln(w, "ID\tVersion Hash\tProvider\tName\tOwner\tStatus\tCreated At\tUpdated At")
+	fmt.Fprintln(w, "--\t------------\t--------\t----\t-----\t------\t----------\t----------")
 
 	for _, model := range models {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			valueOrDash(model.ID),
+			valueOrDash(modelVersionHash(model)),
 			valueOrDash(model.Provider),
 			valueOrDash(model.Name),
 			valueOrDash(model.Owner),
@@ -93,6 +94,20 @@ func displayModels(models []*api.Model) {
 	if err := w.Flush(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to render models table: %v\n", err)
 	}
+}
+
+func modelVersionHash(model *api.Model) string {
+	if model == nil {
+		return ""
+	}
+
+	for _, version := range model.Versions {
+		if version != nil && strings.TrimSpace(version.Hash) != "" {
+			return version.Hash
+		}
+	}
+
+	return ""
 }
 
 func valueOrDash(value string) string {

--- a/cmd/model/getModels_test.go
+++ b/cmd/model/getModels_test.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/runpod/runpodctl/api"
+)
+
+func TestModelVersionHash(t *testing.T) {
+	tests := []struct {
+		name  string
+		model *api.Model
+		want  string
+	}{
+		{
+			name: "first hash",
+			model: &api.Model{Versions: []*api.ModelVersion{
+				{Hash: ""},
+				{Hash: "  "},
+				{Hash: "hash-1"},
+				{Hash: "hash-2"},
+			}},
+			want: "hash-1",
+		},
+		{
+			name:  "no versions",
+			model: &api.Model{},
+			want:  "",
+		},
+		{
+			name:  "nil model",
+			model: nil,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := modelVersionHash(tt.model); got != tt.want {
+				t.Fatalf("modelVersionHash() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# CE-1584: Show model version hash in model list

Adds a Version Hash column to runpodctl model list so users can copy the model version hash needed for serverless endpoint model references.

The list output now uses the first non-empty version hash returned for each model and falls back to "-" when no hash is available. Also adds focused unit coverage for hash selection and updates the runpodctl skill note to mention the new output.