### PR TITLE
feat: add agent source tracking to user-agent header

### DIFF
--- a/api/query.go
+++ b/api/query.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/runpod/runpodctl/internal/agent"
 	"github.com/spf13/viper"
 )
 
@@ -58,8 +59,8 @@ func Query(input Input) (res *http.Response, err error) {
 
 	sanitizedVersion := strings.TrimRight(Version, "\r\n")
 	userAgent := "RunPod-CLI/" + sanitizedVersion + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
-	if os.Getenv("CLAUDECODE") == "1" {
-		userAgent += " (via claude-code)"
+	if a := agent.Detect(); a != "" {
+		userAgent += " (via " + a + ")"
 	}
 
 	req.Header.Add("Content-Type", "application/json")

--- a/api/query.go
+++ b/api/query.go
@@ -58,6 +58,9 @@ func Query(input Input) (res *http.Response, err error) {
 
 	sanitizedVersion := strings.TrimRight(Version, "\r\n")
 	userAgent := "RunPod-CLI/" + sanitizedVersion + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
+	if os.Getenv("CLAUDECODE") == "1" {
+		userAgent += " (via claude-code)"
+	}
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Set("User-Agent", userAgent)

--- a/api/query.go
+++ b/api/query.go
@@ -58,10 +58,7 @@ func Query(input Input) (res *http.Response, err error) {
 	}
 
 	sanitizedVersion := strings.TrimRight(Version, "\r\n")
-	userAgent := "RunPod-CLI/" + sanitizedVersion + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
-	if a := agent.Detect(); a != "" {
-		userAgent += " (via " + a + ")"
-	}
+	userAgent := "RunPod-CLI/" + sanitizedVersion + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")" + agent.Suffix()
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Set("User-Agent", userAgent)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -64,6 +64,16 @@ func KnownEnvVars() []string {
 	return append(vars, standardEnvVars...)
 }
 
+// Suffix returns the " (via <id>)" User-Agent fragment for the detected agent,
+// or an empty string when none is detected. Centralizing the fragment here
+// keeps the tag format identical across every client's User-Agent.
+func Suffix() string {
+	if a := Detect(); a != "" {
+		return " (via " + a + ")"
+	}
+	return ""
+}
+
 // Detect returns the identifier of the AI coding agent driving the CLI, or an
 // empty string if none is detected. Specific harness markers take priority
 // over the generic AI_AGENT signal.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -7,7 +7,10 @@
 // https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/agent-harnesses.ts
 package agent
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 // harness maps an agent identifier to the environment variables that identify
 // it. Detection matches if ANY of the listed variables is set to a non-empty
@@ -45,11 +48,13 @@ var harnesses = []harness{
 }
 
 // standardEnvVars are generic variables any tool can set to identify itself.
-// When set, the value is used directly as the agent id.
-var standardEnvVars = []string{"AI_AGENT", "AGENT"}
+// When set, the value is sanitized and used as the agent id. Only AI_AGENT is
+// honored: a bare AGENT is too common in unrelated environments (CI runners,
+// shell setups) and would attribute traffic to arbitrary values.
+var standardEnvVars = []string{"AI_AGENT"}
 
 // KnownEnvVars returns every environment variable the registry inspects,
-// including the standard AI_AGENT/AGENT signals. Useful for tests that need to
+// including the standard AI_AGENT signal. Useful for tests that need to
 // isolate detection from the ambient environment.
 func KnownEnvVars() []string {
 	var vars []string
@@ -61,7 +66,7 @@ func KnownEnvVars() []string {
 
 // Detect returns the identifier of the AI coding agent driving the CLI, or an
 // empty string if none is detected. Specific harness markers take priority
-// over the generic AI_AGENT/AGENT signal.
+// over the generic AI_AGENT signal.
 func Detect() string {
 	for _, h := range harnesses {
 		for _, env := range h.envVars {
@@ -71,9 +76,28 @@ func Detect() string {
 		}
 	}
 	for _, env := range standardEnvVars {
-		if v := os.Getenv(env); v != "" {
+		if v := sanitize(os.Getenv(env)); v != "" {
 			return v
 		}
 	}
 	return ""
+}
+
+// sanitize trims the value and keeps only User-Agent-safe characters
+// ([A-Za-z0-9._-]), capped at 64 runes, so an arbitrary env value can't
+// produce a malformed header.
+func sanitize(v string) string {
+	v = strings.TrimSpace(v)
+	var b strings.Builder
+	for _, r := range v {
+		if b.Len() >= 64 {
+			break
+		}
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,0 +1,79 @@
+// Package agent detects which AI coding agent (if any) is driving the CLI.
+//
+// Detection is based on the environment variables that agent harnesses set in
+// the processes they spawn. The registry mirrors Hugging Face's public
+// agent-harnesses list so that traffic is attributed under the same agent
+// identifiers across tools:
+// https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/agent-harnesses.ts
+package agent
+
+import "os"
+
+// harness maps an agent identifier to the environment variables that identify
+// it. Detection matches if ANY of the listed variables is set to a non-empty
+// value.
+type harness struct {
+	id      string
+	envVars []string
+}
+
+// harnesses is checked in order; the first match wins. Order matters: more
+// specific signals must come before broader ones that they can co-occur with
+// (e.g. cowork before claude-code, cursor-cli before cursor).
+var harnesses = []harness{
+	{id: "antigravity", envVars: []string{"ANTIGRAVITY_AGENT"}},
+	{id: "augment-cli", envVars: []string{"AUGMENT_AGENT"}},
+	{id: "cline", envVars: []string{"CLINE_ACTIVE"}},
+	{id: "cowork", envVars: []string{"CLAUDE_CODE_IS_COWORK"}},
+	{id: "claude-code", envVars: []string{"CLAUDECODE", "CLAUDE_CODE"}},
+	{id: "codex", envVars: []string{"CODEX_SANDBOX", "CODEX_CI", "CODEX_THREAD_ID"}},
+	{id: "crush", envVars: []string{"CRUSH"}},
+	{id: "gemini-cli", envVars: []string{"GEMINI_CLI"}},
+	{id: "github-copilot", envVars: []string{"COPILOT_MODEL", "COPILOT_ALLOW_ALL", "COPILOT_GITHUB_TOKEN"}},
+	{id: "goose", envVars: []string{"GOOSE_TERMINAL"}},
+	{id: "hermes-agent", envVars: []string{"HERMES_SESSION_ID"}},
+	{id: "kilo-code", envVars: []string{"KILOCODE_FEATURE"}},
+	{id: "kiro", envVars: []string{"AGENT_CONTEXT_OUT"}},
+	{id: "openclaw", envVars: []string{"OPENCLAW_SHELL"}},
+	{id: "opencode", envVars: []string{"OPENCODE_CLIENT"}},
+	{id: "pi", envVars: []string{"PI_CODING_AGENT"}},
+	{id: "replit", envVars: []string{"REPL_ID"}},
+	{id: "trae", envVars: []string{"TRAE_AI_SHELL_ID"}},
+	{id: "zed", envVars: []string{"ZED_TERM"}},
+	{id: "cursor-cli", envVars: []string{"CURSOR_AGENT"}},
+	{id: "cursor", envVars: []string{"CURSOR_TRACE_ID"}},
+}
+
+// standardEnvVars are generic variables any tool can set to identify itself.
+// When set, the value is used directly as the agent id.
+var standardEnvVars = []string{"AI_AGENT", "AGENT"}
+
+// KnownEnvVars returns every environment variable the registry inspects,
+// including the standard AI_AGENT/AGENT signals. Useful for tests that need to
+// isolate detection from the ambient environment.
+func KnownEnvVars() []string {
+	var vars []string
+	for _, h := range harnesses {
+		vars = append(vars, h.envVars...)
+	}
+	return append(vars, standardEnvVars...)
+}
+
+// Detect returns the identifier of the AI coding agent driving the CLI, or an
+// empty string if none is detected. Specific harness markers take priority
+// over the generic AI_AGENT/AGENT signal.
+func Detect() string {
+	for _, h := range harnesses {
+		for _, env := range h.envVars {
+			if os.Getenv(env) != "" {
+				return h.id
+			}
+		}
+	}
+	for _, env := range standardEnvVars {
+		if v := os.Getenv(env); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,6 +1,9 @@
 package agent
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func clearAll(t *testing.T) {
 	t.Helper()
@@ -72,5 +75,36 @@ func TestDetect_SpecificBeatsStandard(t *testing.T) {
 	t.Setenv("CLAUDECODE", "1")
 	if got := Detect(); got != "claude-code" {
 		t.Errorf("expected claude-code to take priority, got %q", got)
+	}
+}
+
+func TestDetect_BareAgentNotHonored(t *testing.T) {
+	clearAll(t)
+	t.Setenv("AGENT", "ssh-agent-or-ci-runner")
+	if got := Detect(); got != "" {
+		t.Errorf("expected bare AGENT to be ignored, got %q", got)
+	}
+}
+
+func TestDetect_SanitizesStandardValue(t *testing.T) {
+	cases := map[string]string{
+		"my harness\r\nX-Injected: 1": "myharnessX-Injected1",
+		"  trimmed-agent  ":           "trimmed-agent",
+		"!@#$%":                       "",
+	}
+	for in, want := range cases {
+		t.Run(want, func(t *testing.T) {
+			clearAll(t)
+			t.Setenv("AI_AGENT", in)
+			if got := Detect(); got != want {
+				t.Errorf("AI_AGENT=%q: expected %q, got %q", in, want, got)
+			}
+		})
+	}
+}
+
+func TestSanitize_CapsLength(t *testing.T) {
+	if got := sanitize(strings.Repeat("a", 100)); len(got) != 64 {
+		t.Errorf("expected 64-rune cap, got %d", len(got))
 	}
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,76 @@
+package agent
+
+import "testing"
+
+func clearAll(t *testing.T) {
+	t.Helper()
+	for _, env := range KnownEnvVars() {
+		t.Setenv(env, "")
+	}
+}
+
+func TestDetect_None(t *testing.T) {
+	clearAll(t)
+	if got := Detect(); got != "" {
+		t.Errorf("expected no agent, got %q", got)
+	}
+}
+
+func TestDetect_KnownHarnesses(t *testing.T) {
+	cases := map[string]string{
+		"CLAUDECODE":        "claude-code",
+		"CLAUDE_CODE":       "claude-code",
+		"CODEX_SANDBOX":     "codex",
+		"CODEX_THREAD_ID":   "codex",
+		"GEMINI_CLI":        "gemini-cli",
+		"CURSOR_AGENT":      "cursor-cli",
+		"CURSOR_TRACE_ID":   "cursor",
+		"OPENCODE_CLIENT":   "opencode",
+		"COPILOT_MODEL":     "github-copilot",
+		"ANTIGRAVITY_AGENT": "antigravity",
+	}
+	for env, want := range cases {
+		t.Run(env, func(t *testing.T) {
+			clearAll(t)
+			t.Setenv(env, "1")
+			if got := Detect(); got != want {
+				t.Errorf("env %s: expected %q, got %q", env, want, got)
+			}
+		})
+	}
+}
+
+func TestDetect_CoworkBeatsClaudeCode(t *testing.T) {
+	clearAll(t)
+	t.Setenv("CLAUDECODE", "1")
+	t.Setenv("CLAUDE_CODE_IS_COWORK", "1")
+	if got := Detect(); got != "cowork" {
+		t.Errorf("expected cowork to win, got %q", got)
+	}
+}
+
+func TestDetect_CursorCLIBeatsCursor(t *testing.T) {
+	clearAll(t)
+	t.Setenv("CURSOR_TRACE_ID", "abc")
+	t.Setenv("CURSOR_AGENT", "1")
+	if got := Detect(); got != "cursor-cli" {
+		t.Errorf("expected cursor-cli to win, got %q", got)
+	}
+}
+
+func TestDetect_StandardFallback(t *testing.T) {
+	clearAll(t)
+	t.Setenv("AI_AGENT", "my-harness")
+	if got := Detect(); got != "my-harness" {
+		t.Errorf("expected my-harness, got %q", got)
+	}
+}
+
+func TestDetect_SpecificBeatsStandard(t *testing.T) {
+	clearAll(t)
+	t.Setenv("AI_AGENT", "my-harness")
+	t.Setenv("CLAUDECODE", "1")
+	if got := Detect(); got != "claude-code" {
+		t.Errorf("expected claude-code to take priority, got %q", got)
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -103,6 +103,17 @@ func TestDetect_SanitizesStandardValue(t *testing.T) {
 	}
 }
 
+func TestSuffix(t *testing.T) {
+	clearAll(t)
+	if got := Suffix(); got != "" {
+		t.Errorf("expected empty suffix, got %q", got)
+	}
+	t.Setenv("CLAUDECODE", "1")
+	if got := Suffix(); got != " (via claude-code)" {
+		t.Errorf("expected \" (via claude-code)\", got %q", got)
+	}
+}
+
 func TestSanitize_CapsLength(t *testing.T) {
 	if got := sanitize(strings.Repeat("a", 100)); len(got) != 64 {
 		t.Errorf("expected 64-rune cap, got %d", len(got))

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -18,11 +18,7 @@ import (
 // buildUserAgent constructs the User-Agent string, appending a coding agent
 // source tag when the CLI is driven by a recognized AI agent.
 func buildUserAgent() string {
-	ua := fmt.Sprintf("runpod-cli/%s (%s; %s)", Version, runtime.GOOS, runtime.GOARCH)
-	if a := agent.Detect(); a != "" {
-		ua += " (via " + a + ")"
-	}
-	return ua
+	return fmt.Sprintf("runpod-cli/%s (%s; %s)", Version, runtime.GOOS, runtime.GOARCH) + agent.Suffix()
 }
 
 const (

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -14,6 +14,16 @@ import (
 	"github.com/spf13/viper"
 )
 
+// buildUserAgent constructs the User-Agent string, appending coding agent
+// source tags when the corresponding environment variables are set.
+func buildUserAgent() string {
+	ua := fmt.Sprintf("runpod-cli/%s (%s; %s)", Version, runtime.GOOS, runtime.GOARCH)
+	if os.Getenv("CLAUDECODE") == "1" {
+		ua += " (via claude-code)"
+	}
+	return ua
+}
+
 const (
 	DefaultBaseURL = "https://rest.runpod.io/v1"
 	DefaultTimeout = 30 * time.Second
@@ -52,13 +62,11 @@ func NewClient() (*Client, error) {
 		timeout = DefaultTimeout
 	}
 
-	userAgent := fmt.Sprintf("runpod-cli/%s (%s; %s)", Version, runtime.GOOS, runtime.GOARCH)
-
 	return &Client{
 		baseURL:    baseURL,
 		apiKey:     apiKey,
 		httpClient: &http.Client{Timeout: timeout},
-		userAgent:  userAgent,
+		userAgent:  buildUserAgent(),
 	}, nil
 }
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -11,15 +11,16 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/runpod/runpodctl/internal/agent"
 	"github.com/spf13/viper"
 )
 
-// buildUserAgent constructs the User-Agent string, appending coding agent
-// source tags when the corresponding environment variables are set.
+// buildUserAgent constructs the User-Agent string, appending a coding agent
+// source tag when the CLI is driven by a recognized AI agent.
 func buildUserAgent() string {
 	ua := fmt.Sprintf("runpod-cli/%s (%s; %s)", Version, runtime.GOOS, runtime.GOARCH)
-	if os.Getenv("CLAUDECODE") == "1" {
-		ua += " (via claude-code)"
+	if a := agent.Detect(); a != "" {
+		ua += " (via " + a + ")"
 	}
 	return ua
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -142,6 +143,25 @@ func TestClient_ErrorResponse(t *testing.T) {
 	_, err = client.Get("/notfound", nil)
 	if err == nil {
 		t.Error("expected error for 404 response")
+	}
+}
+
+func TestBuildUserAgent_Default(t *testing.T) {
+	t.Setenv("CLAUDECODE", "")
+	ua := buildUserAgent()
+	if strings.Contains(ua, "via claude-code") {
+		t.Errorf("expected no agent tag, got %s", ua)
+	}
+	if !strings.HasPrefix(ua, "runpod-cli/") {
+		t.Errorf("expected runpod-cli/ prefix, got %s", ua)
+	}
+}
+
+func TestBuildUserAgent_ClaudeCode(t *testing.T) {
+	t.Setenv("CLAUDECODE", "1")
+	ua := buildUserAgent()
+	if !strings.Contains(ua, "(via claude-code)") {
+		t.Errorf("expected claude-code agent tag, got %s", ua)
 	}
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/runpod/runpodctl/internal/agent"
 )
 
 func TestNewClient_NoAPIKey(t *testing.T) {
@@ -147,9 +149,11 @@ func TestClient_ErrorResponse(t *testing.T) {
 }
 
 func TestBuildUserAgent_Default(t *testing.T) {
-	t.Setenv("CLAUDECODE", "")
+	for _, env := range agent.KnownEnvVars() {
+		t.Setenv(env, "")
+	}
 	ua := buildUserAgent()
-	if strings.Contains(ua, "via claude-code") {
+	if strings.Contains(ua, "(via ") {
 		t.Errorf("expected no agent tag, got %s", ua)
 	}
 	if !strings.HasPrefix(ua, "runpod-cli/") {
@@ -158,10 +162,24 @@ func TestBuildUserAgent_Default(t *testing.T) {
 }
 
 func TestBuildUserAgent_ClaudeCode(t *testing.T) {
+	for _, env := range agent.KnownEnvVars() {
+		t.Setenv(env, "")
+	}
 	t.Setenv("CLAUDECODE", "1")
 	ua := buildUserAgent()
 	if !strings.Contains(ua, "(via claude-code)") {
 		t.Errorf("expected claude-code agent tag, got %s", ua)
+	}
+}
+
+func TestBuildUserAgent_Codex(t *testing.T) {
+	for _, env := range agent.KnownEnvVars() {
+		t.Setenv(env, "")
+	}
+	t.Setenv("CODEX_SANDBOX", "seatbelt")
+	ua := buildUserAgent()
+	if !strings.Contains(ua, "(via codex)") {
+		t.Errorf("expected codex agent tag, got %s", ua)
 	}
 }
 

--- a/internal/api/graphql.go
+++ b/internal/api/graphql.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"runtime"
 	"strings"
 	"time"
 
@@ -56,13 +55,11 @@ func NewGraphQLClient() (*GraphQLClient, error) {
 		timeout = 30 * time.Second
 	}
 
-	userAgent := fmt.Sprintf("runpod-cli/%s (%s; %s)", Version, runtime.GOOS, runtime.GOARCH)
-
 	return &GraphQLClient{
 		url:        apiURL,
 		apiKey:     apiKey,
 		httpClient: &http.Client{Timeout: timeout},
-		userAgent:  userAgent,
+		userAgent:  buildUserAgent(),
 	}, nil
 }
 


### PR DESCRIPTION
Appends coding agent source tags to the User-Agent header on all outgoing API requests when the corresponding environment variable is set (e.g. `CLAUDECODE=1` adds `(via claude-code)`). Covers both the REST client and GraphQL client paths.

CON-85