### PR TITLE
fix: STO-138: Fix Model Repo upload completion flow

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -170,11 +170,11 @@ type ModelVersionStatusMutationResult struct {
 
 // AddModelToRepoInput captures the information required to upload a model to the repository.
 type AddModelToRepoInput struct {
+	Owner               string                 `json:"owner,omitempty"`
 	Name                string                 `json:"name"`
 	CredentialType      string                 `json:"credentialType,omitempty"`
 	CredentialReference string                 `json:"credentialReference,omitempty"`
 	ModelStatus         string                 `json:"modelStatus,omitempty"`
-	VersionStatus       string                 `json:"versionStatus,omitempty"`
 	Metadata            map[string]interface{} `json:"metadata,omitempty"`
 }
 
@@ -182,7 +182,6 @@ type AddModelToRepoInput struct {
 type GetModelsInput struct {
 	Provider string `json:"provider,omitempty"`
 	Name     string `json:"name,omitempty"`
-	All      bool   `json:"-"`
 }
 
 // GetModelInput captures the identifiers needed to retrieve a single model.
@@ -199,6 +198,7 @@ type RemoveModelInput struct {
 
 // CreateModelRepoUploadInput defines the payload used to start a multipart upload for a model version.
 type CreateModelRepoUploadInput struct {
+	Owner               string                 `json:"owner,omitempty"`
 	Name                string                 `json:"name,omitempty"`
 	ModelVersionUUID    string                 `json:"modelVersionUuid,omitempty"`
 	FileName            string                 `json:"fileName"`
@@ -233,10 +233,10 @@ func AddModelToRepo(input *AddModelToRepoInput) (*Model, error) {
 		payload[key] = value
 	}
 
+	addString("owner", input.Owner)
 	addString("credentialType", input.CredentialType)
 	addString("credentialReference", input.CredentialReference)
 	addString("modelStatus", input.ModelStatus)
-	addString("versionStatus", input.VersionStatus)
 
 	if len(input.Metadata) > 0 {
 		payload["metadata"] = input.Metadata
@@ -252,10 +252,11 @@ func AddModelToRepo(input *AddModelToRepoInput) (*Model, error) {
                         addModelToRepo(input: $input) {
                                 success
                                 message
-                                model {
-                                        id
-                                        name
-                                        provider
+	                                model {
+	                                        id
+	                                        owner
+	                                        name
+	                                        provider
                                         status
                                         createdAt
                                         updatedAt
@@ -326,19 +327,12 @@ func AddModelToRepo(input *AddModelToRepoInput) (*Model, error) {
 
 // GetModels retrieves models that match the provided filters from the repository.
 func GetModels(input *GetModelsInput) ([]*Model, error) {
-	queryName := "myModels"
-	fieldName := "myModels"
-	if input != nil && input.All {
-		queryName = "models"
-		fieldName = "models"
-	}
-
 	gqlInput := Input{
-		Query: fmt.Sprintf(`
-query %s {
-%s {
-        id
-        owner
+		Query: `
+	query myModels {
+	myModels {
+	        id
+	        owner
         provider
         name
         status
@@ -358,9 +352,9 @@ query %s {
                 createdAt
                 updatedAt
         }
-}
-}
-`, queryName, fieldName),
+	}
+	}
+	`,
 		Variables: nil,
 	}
 
@@ -381,7 +375,6 @@ query %s {
 	var data struct {
 		Data *struct {
 			MyModels []*Model `json:"myModels"`
-			Models   []*Model `json:"models"`
 		} `json:"data"`
 		Errors []*GraphQLError `json:"errors"`
 	}
@@ -395,16 +388,10 @@ query %s {
 		return nil, fmt.Errorf("data is nil: %s", string(rawData))
 	}
 
-	var models []*Model
-	switch fieldName {
-	case "models":
-		models = data.Data.Models
-	default:
-		models = data.Data.MyModels
-	}
+	models := data.Data.MyModels
 
 	if models == nil {
-		return nil, fmt.Errorf("data is nil: %s", string(rawData))
+		models = []*Model{}
 	}
 	if input != nil {
 		if input.Provider != "" {
@@ -645,6 +632,7 @@ func CreateModelRepoUpload(input *CreateModelRepoUploadInput) (*ModelRepoMutatio
 		payload[key] = value
 	}
 
+	addString("owner", input.Owner)
 	addString("partSizeBytes", input.PartSizeBytes)
 	addString("contentType", input.ContentType)
 	addString("credentialType", input.CredentialType)
@@ -683,10 +671,11 @@ func CreateModelRepoUpload(input *CreateModelRepoUploadInput) (*ModelRepoMutatio
                                         completeUrl
                                         abortUrl
                                 }
-                                model {
-                                        id
-                                        name
-                                        provider
+	                                model {
+	                                        id
+	                                        owner
+	                                        name
+	                                        provider
                                         status
                                         updatedAt
                                 }

--- a/api/query.go
+++ b/api/query.go
@@ -20,6 +20,7 @@ type Input struct {
 }
 
 const GraphQLTimeoutKey = "graphqlTimeout"
+const DefaultGraphQLURL = "https://api.runpod.io/graphql"
 
 func Query(input Input) (res *http.Response, err error) {
 	if input.Variables == nil {
@@ -31,9 +32,12 @@ func Query(input Input) (res *http.Response, err error) {
 		return nil, err
 	}
 
-	apiUrl := os.Getenv("RUNPOD_API_URL")
+	apiUrl := os.Getenv("RUNPOD_GRAPHQL_URL")
 	if apiUrl == "" {
 		apiUrl = viper.GetString("apiUrl")
+	}
+	if apiUrl == "" {
+		apiUrl = DefaultGraphQLURL
 	}
 
 	apiKey := os.Getenv("RUNPOD_API_KEY")

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestQueryUsesGraphQLEndpointEnv(t *testing.T) {
+	viper.Reset()
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	restServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("expected query not to use RUNPOD_API_URL")
+	}))
+	defer restServer.Close()
+	t.Setenv("RUNPOD_API_URL", restServer.URL)
+
+	graphqlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input Input
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if input.Query != "query test" {
+			t.Fatalf("unexpected query: %q", input.Query)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{}})
+	}))
+	defer graphqlServer.Close()
+	t.Setenv("RUNPOD_GRAPHQL_URL", graphqlServer.URL)
+
+	res, err := Query(Input{Query: "query test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer res.Body.Close()
+}
+
+func TestQueryFallsBackToConfiguredAPIURL(t *testing.T) {
+	viper.Reset()
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{}})
+	}))
+	defer server.Close()
+	viper.Set("apiUrl", server.URL)
+
+	res, err := Query(Input{Query: "query test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer res.Body.Close()
+}

--- a/cmd/model/addModelToRepo.go
+++ b/cmd/model/addModelToRepo.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"bytes"
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -16,17 +15,18 @@ import (
 	"time"
 
 	"github.com/runpod/runpodctl/api"
+	"github.com/runpod/runpodctl/internal/output"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 var (
+	addModelOwner               string
 	addModelName                string
 	addModelCredentialReference string
 	addModelCredentialType      string
 	addModelStatus              string
-	addModelVersionStatus       string
 	addModelCreateUpload        bool
 	addModelFileName            string
 	addModelFileSize            string
@@ -56,7 +56,7 @@ func setModelGraphQLTimeout(cmd *cobra.Command) {
 		}
 
 		viper.Set(api.GraphQLTimeoutKey, modelGraphQLTimeoutValue)
-		fmt.Printf("--graphql-timeout not set; defaulting to %s for model creation operations\n", modelGraphQLTimeoutValue)
+		fmt.Fprintf(os.Stderr, "--graphql-timeout not set; defaulting to %s for model creation operations\n", modelGraphQLTimeoutValue)
 		return
 	}
 
@@ -68,7 +68,7 @@ func setModelGraphQLTimeout(cmd *cobra.Command) {
 	}
 
 	viper.Set(api.GraphQLTimeoutKey, modelGraphQLTimeoutValue)
-	fmt.Printf("defaulting graphql timeout to %s for model creation operations\n", modelGraphQLTimeoutValue)
+	fmt.Fprintf(os.Stderr, "defaulting graphql timeout to %s for model creation operations\n", modelGraphQLTimeoutValue)
 }
 
 type completedPart struct {
@@ -86,6 +86,19 @@ type modelFile struct {
 	AbsolutePath string
 	RelativePath string
 	Size         int64
+}
+
+type uploadedModelFile struct {
+	RelativePath string `json:"relativePath"`
+	Key          string `json:"key"`
+	SessionID    string `json:"sessionId"`
+	Status       string `json:"status"`
+}
+
+type modelAddOutput struct {
+	Model         *api.Model           `json:"model,omitempty"`
+	Upload        *api.ModelRepoUpload `json:"upload,omitempty"`
+	UploadedFiles []uploadedModelFile  `json:"uploadedFiles,omitempty"`
 }
 
 // TODO: replace the manual completion call with github.com/aws/aws-sdk-go-v2/service/s3's
@@ -121,10 +134,10 @@ func init() {
 }
 
 func bindAddModelFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&addModelOwner, "owner", "", "model owner namespace (user or team owner id)")
 	cmd.Flags().StringVar(&addModelName, "name", "", "model name")
 	cmd.Flags().StringVar(&addModelCredentialReference, "credential-reference", "", "credential reference (if required)")
 	cmd.Flags().StringVar(&addModelCredentialType, "credential-type", "", "credential type (if required)")
-	cmd.Flags().StringVar(&addModelVersionStatus, "version-status", "", "initial model version status")
 	cmd.Flags().StringVar(&addModelStatus, "model-status", "", "initial model status")
 	cmd.Flags().BoolVar(&addModelCreateUpload, "create-upload", false, "create an upload session")
 	cmd.Flags().StringVar(&addModelFileName, "file-name", "", "file name for upload")
@@ -169,11 +182,11 @@ func runAddModel(cmd *cobra.Command, args []string) {
 	}
 
 	input := &api.AddModelToRepoInput{
+		Owner:               addModelOwner,
 		Name:                addModelName,
 		CredentialReference: addModelCredentialReference,
 		CredentialType:      addModelCredentialType,
 		ModelStatus:         addModelStatus,
-		VersionStatus:       addModelVersionStatus,
 		Metadata:            metadata,
 	}
 
@@ -187,16 +200,14 @@ func runAddModel(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if model != nil {
-		fmt.Printf("model %q registered with Model Repo (id: %s)\n", model.Name, model.ID)
-	}
-
 	shouldCreateUpload := addModelCreateUpload || addModelFileName != "" || addModelFileSize != "" || addModelPartSize != "" || addModelContentType != "" || len(addModelMetadata) > 0
 	if !shouldCreateUpload {
+		printModelAddOutput(cmd, modelAddOutput{Model: model})
 		return
 	}
 
 	uploadInput := &api.CreateModelRepoUploadInput{
+		Owner:               addModelOwner,
 		PartSizeBytes:       addModelPartSize,
 		ContentType:         addModelContentType,
 		CredentialReference: addModelCredentialReference,
@@ -207,8 +218,9 @@ func runAddModel(cmd *cobra.Command, args []string) {
 	uploadInput.Name = addModelName
 
 	if len(modelFiles) > 0 {
-		err := uploadModelFiles(modelFiles, uploadInput)
+		uploadedFiles, err := uploadModelFiles(modelFiles, uploadInput)
 		cobra.CheckErr(err)
+		printModelAddOutput(cmd, modelAddOutput{Model: model, UploadedFiles: uploadedFiles})
 		return
 	}
 
@@ -229,9 +241,7 @@ func runAddModel(cmd *cobra.Command, args []string) {
 		cobra.CheckErr(fmt.Errorf("upload response missing upload session details"))
 	}
 
-	uploadJSON, err := json.MarshalIndent(result.Upload, "", "  ")
-	cobra.CheckErr(err)
-	fmt.Printf("multipart upload session created:\n%s\n", string(uploadJSON))
+	printModelAddOutput(cmd, modelAddOutput{Model: model, Upload: result.Upload})
 }
 
 func collectModelFiles(dir string) ([]modelFile, error) {
@@ -288,8 +298,9 @@ func collectModelFiles(dir string) ([]modelFile, error) {
 	return files, nil
 }
 
-func uploadModelFiles(files []modelFile, baseInput *api.CreateModelRepoUploadInput) error {
+func uploadModelFiles(files []modelFile, baseInput *api.CreateModelRepoUploadInput) ([]uploadedModelFile, error) {
 	var modelVersionUUID string
+	uploadedFiles := make([]uploadedModelFile, 0, len(files))
 
 	for i, file := range files {
 		input := *baseInput
@@ -299,47 +310,57 @@ func uploadModelFiles(files []modelFile, baseInput *api.CreateModelRepoUploadInp
 
 		result, err := createModelRepoUpload(&input)
 		if err != nil {
-			return fmt.Errorf("create upload for %s: %w", file.RelativePath, err)
+			return nil, fmt.Errorf("create upload for %s: %w", file.RelativePath, err)
 		}
 		if result.Upload == nil {
-			return fmt.Errorf("upload response missing upload session details for %s", file.RelativePath)
+			return nil, fmt.Errorf("upload response missing upload session details for %s", file.RelativePath)
 		}
 		if modelVersionUUID == "" {
 			if result.Version != nil {
 				modelVersionUUID = strings.TrimSpace(result.Version.UUID)
 			}
 			if modelVersionUUID == "" && i < len(files)-1 {
-				return fmt.Errorf("upload response missing model version uuid for %s", file.RelativePath)
+				return nil, fmt.Errorf("upload response missing model version uuid for %s", file.RelativePath)
 			}
 		}
 
 		if err = completeModelUploadFile(result.Upload, file.AbsolutePath); err != nil {
-			return fmt.Errorf("upload %s: %w", file.RelativePath, err)
+			return nil, fmt.Errorf("upload %s: %w", file.RelativePath, err)
 		}
 
 		if result.Upload.SessionID == "" {
-			return fmt.Errorf("upload %s: missing session identifier for completion", file.RelativePath)
+			return nil, fmt.Errorf("upload %s: missing session identifier for completion", file.RelativePath)
 		}
 
-		completion, err := completeModelRepoUpload(result.Upload.SessionID)
-		if err != nil {
-			return fmt.Errorf("complete upload session for %s: %w", file.RelativePath, err)
-		}
-
-		fmt.Printf("model artifact %q uploaded to %s (session %s status: %s)\n", file.RelativePath, result.Upload.Key, completion.SessionID, completion.Status)
+		uploadedFiles = append(uploadedFiles, uploadedModelFile{
+			RelativePath: file.RelativePath,
+			Key:          result.Upload.Key,
+			SessionID:    result.Upload.SessionID,
+		})
 	}
 
-	return nil
+	for i := range uploadedFiles {
+		completion, err := completeModelRepoUpload(uploadedFiles[i].SessionID)
+		if err != nil {
+			return nil, fmt.Errorf("complete upload session for %s: %w", uploadedFiles[i].RelativePath, err)
+		}
+
+		uploadedFiles[i].SessionID = completion.SessionID
+		uploadedFiles[i].Status = completion.Status
+	}
+
+	return uploadedFiles, nil
+}
+
+func printModelAddOutput(cmd *cobra.Command, result modelAddOutput) {
+	format := output.ParseFormat(cmd.Flag("output").Value.String())
+	cobra.CheckErr(output.Print(result, &output.Config{Format: format}))
 }
 
 func completeModelUpload(upload *api.ModelRepoUpload, artifactPath string) error {
 	if upload == nil {
 		return fmt.Errorf("upload details are required")
 	}
-	if len(upload.Parts) == 0 {
-		return fmt.Errorf("upload does not contain any parts")
-	}
-
 	file, err := os.Open(artifactPath)
 	if err != nil {
 		return fmt.Errorf("open artifact: %w", err)
@@ -349,6 +370,18 @@ func completeModelUpload(upload *api.ModelRepoUpload, artifactPath string) error
 	fileInfo, err := file.Stat()
 	if err != nil {
 		return fmt.Errorf("stat artifact: %w", err)
+	}
+
+	totalSize := fileInfo.Size()
+	if totalSize == 0 {
+		if len(upload.Parts) > 0 {
+			return fmt.Errorf("zero-byte upload should not contain any parts")
+		}
+		return nil
+	}
+
+	if len(upload.Parts) == 0 {
+		return fmt.Errorf("upload does not contain any parts")
 	}
 
 	parts := make([]*api.ModelRepoUploadPart, len(upload.Parts))
@@ -362,7 +395,6 @@ func completeModelUpload(upload *api.ModelRepoUpload, artifactPath string) error
 		return fmt.Errorf("invalid part size %d", partSize)
 	}
 
-	totalSize := fileInfo.Size()
 	var offset int64
 	completed := make([]completedPart, 0, len(parts))
 

--- a/cmd/model/addModelToRepo_timeout_test.go
+++ b/cmd/model/addModelToRepo_timeout_test.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -106,17 +108,24 @@ func TestUploadModelFilesUsesModelVersionUUIDAfterFirstFile(t *testing.T) {
 			},
 		}, nil
 	}
+	var events []string
+	var uploadedArtifacts []string
 	completeModelUploadFile = func(upload *api.ModelRepoUpload, artifactPath string) error {
+		events = append(events, "upload:"+artifactPath)
+		uploadedArtifacts = append(uploadedArtifacts, artifactPath)
 		return nil
 	}
+	var completedSessions []string
 	completeModelRepoUpload = func(sessionID string) (*api.CompleteModelRepoUploadResult, error) {
+		events = append(events, "complete:"+sessionID)
+		completedSessions = append(completedSessions, sessionID)
 		return &api.CompleteModelRepoUploadResult{
 			SessionID: sessionID,
 			Status:    "completed",
 		}, nil
 	}
 
-	err := uploadModelFiles(files, &api.CreateModelRepoUploadInput{Name: "test-model"})
+	uploadedFiles, err := uploadModelFiles(files, &api.CreateModelRepoUploadInput{Name: "test-model"})
 	if err != nil {
 		t.Fatalf("uploadModelFiles returned error: %v", err)
 	}
@@ -131,5 +140,61 @@ func TestUploadModelFilesUsesModelVersionUUIDAfterFirstFile(t *testing.T) {
 		if calls[i].ModelVersionUUID != "version-uuid" {
 			t.Fatalf("expected call %d to use modelVersionUuid %q, got %q", i, "version-uuid", calls[i].ModelVersionUUID)
 		}
+	}
+	if len(uploadedArtifacts) != len(files) {
+		t.Fatalf("expected %d uploaded artifacts, got %d", len(files), len(uploadedArtifacts))
+	}
+	for i, file := range files {
+		if uploadedArtifacts[i] != file.AbsolutePath {
+			t.Fatalf("expected uploaded artifact %d to be %q, got %q", i, file.AbsolutePath, uploadedArtifacts[i])
+		}
+	}
+	expectedCompletedSessions := []string{"session-a.bin", "session-b.bin", "session-c.bin"}
+	if len(completedSessions) != len(expectedCompletedSessions) {
+		t.Fatalf("expected %d completed sessions, got %d", len(expectedCompletedSessions), len(completedSessions))
+	}
+	for i, expected := range expectedCompletedSessions {
+		if completedSessions[i] != expected {
+			t.Fatalf("expected completed session %d to be %q, got %q", i, expected, completedSessions[i])
+		}
+	}
+	if len(uploadedFiles) != len(expectedCompletedSessions) {
+		t.Fatalf("expected %d uploaded files, got %d", len(expectedCompletedSessions), len(uploadedFiles))
+	}
+	for i, expected := range expectedCompletedSessions {
+		if uploadedFiles[i].SessionID != expected {
+			t.Fatalf("expected uploaded file session %d to be %q, got %q", i, expected, uploadedFiles[i].SessionID)
+		}
+		if uploadedFiles[i].Status != "completed" {
+			t.Fatalf("expected uploaded file status %d to be completed, got %q", i, uploadedFiles[i].Status)
+		}
+	}
+	expectedEvents := []string{
+		"upload:/tmp/a.bin",
+		"upload:/tmp/b.bin",
+		"upload:/tmp/c.bin",
+		"complete:session-a.bin",
+		"complete:session-b.bin",
+		"complete:session-c.bin",
+	}
+	if len(events) != len(expectedEvents) {
+		t.Fatalf("expected %d upload/completion events, got %d", len(expectedEvents), len(events))
+	}
+	for i, expected := range expectedEvents {
+		if events[i] != expected {
+			t.Fatalf("expected event %d to be %q, got %q", i, expected, events[i])
+		}
+	}
+}
+
+func TestCompleteModelUploadAllowsZeroByteFileWithNoParts(t *testing.T) {
+	artifactPath := filepath.Join(t.TempDir(), "empty.bin")
+	if err := os.WriteFile(artifactPath, nil, 0600); err != nil {
+		t.Fatalf("write empty artifact: %v", err)
+	}
+
+	err := completeModelUpload(&api.ModelRepoUpload{}, artifactPath)
+	if err != nil {
+		t.Fatalf("expected zero-byte upload with no parts to succeed, got %v", err)
 	}
 }

--- a/cmd/model/errors.go
+++ b/cmd/model/errors.go
@@ -2,10 +2,10 @@ package model
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/runpod/runpodctl/api"
+	"github.com/runpod/runpodctl/internal/output"
 )
 
 func handleModelRepoError(err error) bool {
@@ -13,11 +13,11 @@ func handleModelRepoError(err error) bool {
 		return false
 	}
 	if errors.Is(err, api.ErrModelRepoNotImplemented) {
-		fmt.Println(api.ErrModelRepoNotImplemented.Error())
+		output.Error(api.ErrModelRepoNotImplemented)
 		return true
 	}
 	if strings.Contains(err.Error(), "Model Repo feature is not enabled for this user") {
-		fmt.Println(err.Error())
+		output.Error(err)
 		return true
 	}
 	return false

--- a/cmd/model/getModels.go
+++ b/cmd/model/getModels.go
@@ -1,14 +1,10 @@
 package model
 
 import (
-	"fmt"
-	"os"
-	"strconv"
 	"strings"
-	"text/tabwriter"
-	"time"
 
 	"github.com/runpod/runpodctl/api"
+	"github.com/runpod/runpodctl/internal/output"
 
 	"github.com/spf13/cobra"
 )
@@ -16,7 +12,6 @@ import (
 var (
 	getProvider string
 	getName     string
-	getAll      bool
 )
 
 var listCmd = &cobra.Command{
@@ -45,14 +40,12 @@ func init() {
 func bindModelListFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&getProvider, "provider", "", "filter by provider")
 	cmd.Flags().StringVar(&getName, "name", "", "filter by model name")
-	cmd.Flags().BoolVar(&getAll, "all", false, "include all models (not just yours)")
 }
 
 func runModelList(cmd *cobra.Command, args []string) {
 	input := &api.GetModelsInput{
 		Provider: getProvider,
 		Name:     getName,
-		All:      getAll,
 	}
 
 	models, err := api.GetModels(input)
@@ -65,35 +58,8 @@ func runModelList(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if len(models) == 0 {
-		fmt.Println("no models found")
-		return
-	}
-
-	displayModels(models)
-}
-
-func displayModels(models []*api.Model) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-
-	fmt.Fprintln(w, "ID\tVersion Hash\tProvider\tName\tOwner\tStatus\tCreated At\tUpdated At")
-	fmt.Fprintln(w, "--\t------------\t--------\t----\t-----\t------\t----------\t----------")
-
-	for _, model := range models {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			valueOrDash(model.ID),
-			valueOrDash(modelVersionHash(model)),
-			valueOrDash(model.Provider),
-			valueOrDash(model.Name),
-			valueOrDash(model.Owner),
-			valueOrDash(model.Status),
-			formatTimestamp(model.CreatedAt),
-			formatTimestamp(model.UpdatedAt))
-	}
-
-	if err := w.Flush(); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to render models table: %v\n", err)
-	}
+	format := output.ParseFormat(cmd.Flag("output").Value.String())
+	cobra.CheckErr(output.Print(models, &output.Config{Format: format}))
 }
 
 func modelVersionHash(model *api.Model) string {
@@ -108,48 +74,4 @@ func modelVersionHash(model *api.Model) string {
 	}
 
 	return ""
-}
-
-func valueOrDash(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "-"
-	}
-	return value
-}
-
-func formatTimestamp(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return "-"
-	}
-
-	ts, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		return raw
-	}
-
-	switch len(raw) {
-	case 10:
-		return time.Unix(ts, 0).UTC().Format(time.RFC3339)
-	case 13:
-		sec := ts / 1_000
-		nsec := (ts % 1_000) * int64(time.Millisecond)
-		return time.Unix(sec, nsec).UTC().Format(time.RFC3339)
-	case 16:
-		sec := ts / 1_000_000
-		nsec := (ts % 1_000_000) * int64(time.Microsecond)
-		return time.Unix(sec, nsec).UTC().Format(time.RFC3339)
-	case 19:
-		sec := ts / 1_000_000_000
-		nsec := ts % 1_000_000_000
-		return time.Unix(sec, nsec).UTC().Format(time.RFC3339)
-	default:
-		if ts > 1_000_000_000_000 {
-			sec := ts / 1_000
-			nsec := (ts % 1_000) * int64(time.Millisecond)
-			return time.Unix(sec, nsec).UTC().Format(time.RFC3339)
-		}
-		return time.Unix(ts, 0).UTC().Format(time.RFC3339)
-	}
 }

--- a/cmd/model/getModels_test.go
+++ b/cmd/model/getModels_test.go
@@ -42,3 +42,15 @@ func TestModelVersionHash(t *testing.T) {
 		})
 	}
 }
+
+func TestModelCommandFlags(t *testing.T) {
+	if addCmd.Flags().Lookup("owner") == nil {
+		t.Fatal("expected model add --owner flag")
+	}
+	if addCmd.Flags().Lookup("version-status") != nil {
+		t.Fatal("did not expect model add --version-status flag")
+	}
+	if listCmd.Flags().Lookup("all") != nil {
+		t.Fatal("did not expect model list --all flag")
+	}
+}

--- a/cmd/model/removeModel.go
+++ b/cmd/model/removeModel.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/runpod/runpodctl/api"
+	"github.com/runpod/runpodctl/internal/output"
 
 	"github.com/spf13/cobra"
 )
@@ -66,19 +67,6 @@ func runRemoveModel(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	fmt.Println("model removal requested")
-
-	if result != nil && result.Model != nil && len(result.Model.Versions) > 0 {
-		fmt.Println("affected versions:")
-		for _, version := range result.Model.Versions {
-			if version == nil {
-				continue
-			}
-			hash := version.Hash
-			if hash == "" {
-				hash = version.VersionHash
-			}
-			fmt.Printf("- %s (%s)\n", hash, version.Status)
-		}
-	}
+	format := output.ParseFormat(cmd.Flag("output").Value.String())
+	cobra.CheckErr(output.Print(result, &output.Config{Format: format}))
 }

--- a/docs/runpodctl_model_add.md
+++ b/docs/runpodctl_model_add.md
@@ -24,8 +24,8 @@ runpodctl model add [flags]
       --model-path string             directory containing model files to upload
       --model-status string           initial model status
       --name string                   model name
+      --owner string                  model owner namespace (user or team owner id)
       --part-size string              multipart upload part size in bytes
-      --version-status string         initial model version status
 ```
 
 ### Options inherited from parent commands

--- a/docs/runpodctl_model_list.md
+++ b/docs/runpodctl_model_list.md
@@ -13,7 +13,6 @@ runpodctl model list [flags]
 ### Options
 
 ```
-      --all               include all models (not just yours)
   -h, --help              help for list
       --name string       filter by model name
       --provider string   filter by provider


### PR DESCRIPTION
# STO-138: Fix Model Repo upload completion flow

`runpodctl` completed each Model Repo upload session immediately after uploading that file, which could let backend hashing run before the full directory contents existed. Updated the CLI to complete sessions only after all files are uploaded, and support zero-byte files that require no multipart part uploads.

`runpodctl` Model Repo functionality should also correctly use `RUNPOD_GRAPHQL_URL` as the env var for determing the GraphQL endpoint.