### PR TITLE
SLS-238: pin runpod/pytorch README ref to existing tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ runpodctl pod list
 runpodctl pod get pod_id
 
 # create a pod
-runpodctl pod create --image=runpod/pytorch:latest --gpu-id=NVIDIA_A100
+runpodctl pod create --image=runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04 --gpu-id=NVIDIA_A100
 
 # start/stop/delete a pod
 runpodctl pod start pod_id


### PR DESCRIPTION
## Summary

SLS-8 flipped Layer 2 image verification to `enforce`. Pod-creates that reference a tag returning HTTP 404 now hard-fail instead of proceeding.

The README's `pod create` example uses `runpod/pytorch:latest`, which currently 404s. Customers copy-pasting the documented command hit an immediate enforce failure.

## Change

Pinned the README reference to a published tag:

- `runpod/pytorch:latest` -> `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04`

## Test plan

- `grep -rn 'runpod/pytorch:latest'` returns zero hits after the change.
- Pinned tag is a published, resolvable image (no 404 under Layer 2 enforce).

Ref: SLS-238