### PR TITLE
feat: add registry auth and port labels to templates

### DIFF
--- a/cmd/template/create.go
+++ b/cmd/template/create.go
@@ -15,8 +15,10 @@ var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "create a new template",
 	Long:  "create a new template",
-	Args:  cobra.NoArgs,
-	RunE:  runCreate,
+	Example: `  runpodctl template create --name private-gpu --image registry.example.com/team/image:tag --registry-auth-id <registry-auth-id>
+  runpodctl template create --name dev --image example/image:tag --ports "22/tcp,8888/http" --port-labels "22=ssh,8888=jupyter lab"`,
+	Args: cobra.NoArgs,
+	RunE: runCreate,
 }
 
 var (
@@ -24,6 +26,7 @@ var (
 	createImageName         string
 	createIsServerless      bool
 	createPorts             string
+	createPortLabels        string
 	createDockerEntrypoint  string
 	createDockerStartCmd    string
 	createEnv               string
@@ -31,6 +34,7 @@ var (
 	createVolumeInGb        int
 	createVolumeMountPath   string
 	createReadme            string
+	createRegistryAuthID    string
 )
 
 func init() {
@@ -38,6 +42,7 @@ func init() {
 	createCmd.Flags().StringVar(&createImageName, "image", "", "docker image name (required)")
 	createCmd.Flags().BoolVar(&createIsServerless, "serverless", false, "is this a serverless template")
 	createCmd.Flags().StringVar(&createPorts, "ports", "", "comma-separated list of ports")
+	createCmd.Flags().StringVar(&createPortLabels, "port-labels", "", "port labels as port=name pairs or json")
 	createCmd.Flags().StringVar(&createDockerEntrypoint, "docker-entrypoint", "", "comma-separated docker entrypoint commands")
 	createCmd.Flags().StringVar(&createDockerStartCmd, "docker-start-cmd", "", "comma-separated docker start commands")
 	createCmd.Flags().StringVar(&createEnv, "env", "", "environment variables as json object")
@@ -45,12 +50,28 @@ func init() {
 	createCmd.Flags().IntVar(&createVolumeInGb, "volume-in-gb", 0, "volume size in gb")
 	createCmd.Flags().StringVar(&createVolumeMountPath, "volume-mount-path", "/workspace", "volume mount path")
 	createCmd.Flags().StringVar(&createReadme, "readme", "", "readme content")
+	createCmd.Flags().StringVar(&createRegistryAuthID, "registry-auth-id", "", "container registry auth id (from 'runpodctl registry list')")
 
 	createCmd.MarkFlagRequired("name")  //nolint:errcheck
 	createCmd.MarkFlagRequired("image") //nolint:errcheck
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
+	var portLabels []api.TemplatePortConfig
+	if cmd.Flags().Changed("port-labels") {
+		var err error
+		portLabels, err = parsePortLabels(createPortLabels)
+		if err != nil {
+			return err
+		}
+		if len(portLabels) > 0 && strings.TrimSpace(createPorts) == "" {
+			return fmt.Errorf("--port-labels requires --ports when creating a template")
+		}
+		if err := validatePortLabelsAgainstPorts(portLabels, createPorts); err != nil {
+			return err
+		}
+	}
+
 	client, err := api.NewClient()
 	if err != nil {
 		output.Error(err)
@@ -58,11 +79,12 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	req := &api.TemplateCreateRequest{
-		Name:              createName,
-		ImageName:         createImageName,
-		IsServerless:      createIsServerless,
-		ContainerDiskInGb: createContainerDiskInGb,
-		Readme:            createReadme,
+		Name:                    createName,
+		ImageName:               createImageName,
+		IsServerless:            createIsServerless,
+		ContainerDiskInGb:       createContainerDiskInGb,
+		ContainerRegistryAuthID: strings.TrimSpace(createRegistryAuthID),
+		Readme:                  createReadme,
 	}
 
 	// serverless templates do not support volume fields
@@ -94,6 +116,48 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create template: %w", err)
 	}
 
+	if len(portLabels) > 0 {
+		graphqlClient, labelErr := api.NewGraphQLClient()
+		if labelErr == nil {
+			overrides := createPortLabelOverrides(req)
+			labelErr = graphqlClient.UpdateTemplatePortLabels(template.ID, portLabels, overrides)
+		}
+		if labelErr != nil {
+			cleanupErr := client.DeleteTemplate(template.ID)
+			if cleanupErr != nil {
+				labelErr = fmt.Errorf("failed to set port labels: %v; failed to clean up template %s: %w", labelErr, template.ID, cleanupErr)
+			} else {
+				labelErr = fmt.Errorf("failed to set port labels: %w", labelErr)
+			}
+			output.Error(labelErr)
+			return labelErr
+		}
+		template.PortsConfig = portLabels
+	}
+	if req.ContainerRegistryAuthID != "" {
+		template.ContainerRegistryAuthID = req.ContainerRegistryAuthID
+	}
+
 	format := output.ParseFormat(cmd.Flag("output").Value.String())
 	return output.Print(template, &output.Config{Format: format})
+}
+
+func createPortLabelOverrides(req *api.TemplateCreateRequest) *api.TemplatePortLabelOverrides {
+	overrides := &api.TemplatePortLabelOverrides{
+		Name:              &req.Name,
+		ImageName:         &req.ImageName,
+		IsServerless:      &req.IsServerless,
+		Ports:             &req.Ports,
+		Env:               &req.Env,
+		ContainerDiskInGb: &req.ContainerDiskInGb,
+		Readme:            &req.Readme,
+	}
+	if req.ContainerRegistryAuthID != "" {
+		overrides.ContainerRegistryAuthID = &req.ContainerRegistryAuthID
+	}
+	if !req.IsServerless {
+		overrides.VolumeInGb = &req.VolumeInGb
+		overrides.VolumeMountPath = &req.VolumeMountPath
+	}
+	return overrides
 }

--- a/cmd/template/flags_test.go
+++ b/cmd/template/flags_test.go
@@ -1,0 +1,22 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestTemplateCreateAndUpdateHaveRegistryAndPortLabelFlags(t *testing.T) {
+	commands := map[string]*cobra.Command{
+		"create": createCmd,
+		"update": updateCmd,
+	}
+
+	for commandName, command := range commands {
+		for _, flagName := range []string{"registry-auth-id", "port-labels"} {
+			if command.Flags().Lookup(flagName) == nil {
+				t.Errorf("expected template %s to have --%s", commandName, flagName)
+			}
+		}
+	}
+}

--- a/cmd/template/port_labels.go
+++ b/cmd/template/port_labels.go
@@ -1,0 +1,120 @@
+package template
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/runpod/runpodctl/internal/api"
+)
+
+func parsePortLabels(raw string) ([]api.TemplatePortConfig, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return []api.TemplatePortConfig{}, nil
+	}
+
+	var labels []api.TemplatePortConfig
+	switch raw[0] {
+	case '{':
+		var values map[string]string
+		if err := json.Unmarshal([]byte(raw), &values); err != nil {
+			return nil, fmt.Errorf("invalid port labels json: %w", err)
+		}
+		ports := make([]string, 0, len(values))
+		for port := range values {
+			ports = append(ports, port)
+		}
+		sort.Slice(ports, func(i, j int) bool {
+			left, leftErr := strconv.Atoi(strings.TrimSpace(strings.SplitN(ports[i], "/", 2)[0]))
+			right, rightErr := strconv.Atoi(strings.TrimSpace(strings.SplitN(ports[j], "/", 2)[0]))
+			if leftErr == nil && rightErr == nil && left != right {
+				return left < right
+			}
+			return ports[i] < ports[j]
+		})
+		for _, port := range ports {
+			labels = append(labels, api.TemplatePortConfig{Port: port, Name: values[port]})
+		}
+	case '[':
+		if err := json.Unmarshal([]byte(raw), &labels); err != nil {
+			return nil, fmt.Errorf("invalid port labels json: %w", err)
+		}
+	default:
+		for _, item := range strings.Split(raw, ",") {
+			parts := strings.SplitN(item, "=", 2)
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid port label %q: expected port=name", strings.TrimSpace(item))
+			}
+			labels = append(labels, api.TemplatePortConfig{Port: parts[0], Name: parts[1]})
+		}
+	}
+
+	seen := make(map[string]struct{}, len(labels))
+	for i := range labels {
+		port, err := normalizePortLabelPort(labels[i].Port)
+		if err != nil {
+			return nil, err
+		}
+		name := strings.TrimSpace(labels[i].Name)
+		if name == "" {
+			return nil, fmt.Errorf("port label name is required for port %s", port)
+		}
+		if _, exists := seen[port]; exists {
+			return nil, fmt.Errorf("duplicate port label for %s", port)
+		}
+		seen[port] = struct{}{}
+		labels[i] = api.TemplatePortConfig{Port: port, Name: name}
+	}
+
+	return labels, nil
+}
+
+func normalizePortLabelPort(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	parts := strings.Split(value, "/")
+	if len(parts) > 2 {
+		return "", fmt.Errorf("invalid port %q", raw)
+	}
+	if len(parts) == 2 {
+		protocol := strings.ToLower(strings.TrimSpace(parts[1]))
+		if protocol != "tcp" && protocol != "http" {
+			return "", fmt.Errorf("unsupported protocol %q for port %s", protocol, strings.TrimSpace(parts[0]))
+		}
+	}
+
+	port, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return "", fmt.Errorf("invalid port %q", raw)
+	}
+	if port < 1 || port > 65535 {
+		return "", fmt.Errorf("port %d is outside the valid range 1-65535", port)
+	}
+
+	return strconv.Itoa(port), nil
+}
+
+func validatePortLabelsAgainstPorts(labels []api.TemplatePortConfig, rawPorts string) error {
+	available := make(map[string]struct{})
+	for _, value := range strings.Split(rawPorts, ",") {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		port, err := normalizePortLabelPort(value)
+		if err != nil {
+			return fmt.Errorf("invalid --ports value %q: %w", value, err)
+		}
+		available[port] = struct{}{}
+	}
+
+	for _, label := range labels {
+		if _, exists := available[label.Port]; !exists {
+			return fmt.Errorf("port label %s does not match any value in --ports", label.Port)
+		}
+	}
+
+	return nil
+}

--- a/cmd/template/port_labels_test.go
+++ b/cmd/template/port_labels_test.go
@@ -1,0 +1,86 @@
+package template
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/runpod/runpodctl/internal/api"
+)
+
+func TestParsePortLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []api.TemplatePortConfig
+	}{
+		{
+			name: "pairs",
+			raw:  "22/tcp=SSH, 8888/http=Jupyter Lab",
+			want: []api.TemplatePortConfig{{Port: "22", Name: "SSH"}, {Port: "8888", Name: "Jupyter Lab"}},
+		},
+		{
+			name: "json object",
+			raw:  `{"8888":"Jupyter Lab","22/tcp":"SSH"}`,
+			want: []api.TemplatePortConfig{{Port: "22", Name: "SSH"}, {Port: "8888", Name: "Jupyter Lab"}},
+		},
+		{
+			name: "json array",
+			raw:  `[{"port":"22/tcp","name":"SSH"},{"port":"8888","name":"Jupyter Lab"}]`,
+			want: []api.TemplatePortConfig{{Port: "22", Name: "SSH"}, {Port: "8888", Name: "Jupyter Lab"}},
+		},
+		{
+			name: "empty clears labels",
+			raw:  "",
+			want: []api.TemplatePortConfig{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePortLabels(tt.raw)
+			if err != nil {
+				t.Fatalf("parsePortLabels() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parsePortLabels() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePortLabelsRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		raw       string
+		wantError string
+	}{
+		{raw: "22", wantError: "expected port=name"},
+		{raw: "abc=ssh", wantError: "invalid port"},
+		{raw: "22/udp=ssh", wantError: "unsupported protocol"},
+		{raw: "70000=ssh", wantError: "outside the valid range"},
+		{raw: "22=", wantError: "name is required"},
+		{raw: "22=ssh,22/tcp=shell", wantError: "duplicate port label"},
+	}
+
+	for _, tt := range tests {
+		_, err := parsePortLabels(tt.raw)
+		if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+			t.Fatalf("parsePortLabels(%q) error = %v, want substring %q", tt.raw, err, tt.wantError)
+		}
+	}
+}
+
+func TestValidatePortLabelsAgainstPorts(t *testing.T) {
+	labels := []api.TemplatePortConfig{{Port: "22", Name: "SSH"}, {Port: "8888", Name: "Jupyter Lab"}}
+	if err := validatePortLabelsAgainstPorts(labels, "22/tcp,8888/http"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := validatePortLabelsAgainstPorts(labels, "22/tcp"); err == nil || !strings.Contains(err.Error(), "8888") {
+		t.Fatalf("expected missing port error, got %v", err)
+	}
+
+	if err := validatePortLabelsAgainstPorts(labels[:1], "22/udp"); err == nil || !strings.Contains(err.Error(), "unsupported protocol") {
+		t.Fatalf("expected invalid protocol error, got %v", err)
+	}
+}

--- a/cmd/template/update.go
+++ b/cmd/template/update.go
@@ -15,30 +15,51 @@ var updateCmd = &cobra.Command{
 	Use:   "update <template-id>",
 	Short: "update a template",
 	Long:  "update an existing template",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runUpdate,
+	Example: `  runpodctl template update <template-id> --registry-auth-id <registry-auth-id>
+  runpodctl template update <template-id> --port-labels "22=ssh,8888=jupyter lab"`,
+	Args: cobra.ExactArgs(1),
+	RunE: runUpdate,
 }
 
 var (
 	updateName              string
 	updateImageName         string
 	updatePorts             string
+	updatePortLabels        string
 	updateEnv               string
 	updateReadme            string
 	updateContainerDiskInGb int
+	updateRegistryAuthID    string
 )
 
 func init() {
 	updateCmd.Flags().StringVar(&updateName, "name", "", "new template name")
 	updateCmd.Flags().StringVar(&updateImageName, "image", "", "new docker image name")
 	updateCmd.Flags().StringVar(&updatePorts, "ports", "", "new comma-separated list of ports")
+	updateCmd.Flags().StringVar(&updatePortLabels, "port-labels", "", "new port labels as port=name pairs or json; pass an empty value to clear")
 	updateCmd.Flags().StringVar(&updateEnv, "env", "", "new environment variables as json object")
 	updateCmd.Flags().StringVar(&updateReadme, "readme", "", "new readme content")
 	updateCmd.Flags().IntVar(&updateContainerDiskInGb, "container-disk-in-gb", -1, "new container disk size in gb")
+	updateCmd.Flags().StringVar(&updateRegistryAuthID, "registry-auth-id", "", "new container registry auth id; pass an empty value to clear")
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
 	templateID := args[0]
+	portLabelsChanged := cmd.Flags().Changed("port-labels")
+
+	var portLabels []api.TemplatePortConfig
+	if portLabelsChanged {
+		var err error
+		portLabels, err = parsePortLabels(updatePortLabels)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(updatePorts) != "" {
+			if err := validatePortLabelsAgainstPorts(portLabels, updatePorts); err != nil {
+				return err
+			}
+		}
+	}
 
 	client, err := api.NewClient()
 	if err != nil {
@@ -70,11 +91,65 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		req.ContainerDiskInGb = &updateContainerDiskInGb
 	}
 
-	template, err := client.UpdateTemplate(templateID, req)
+	registryAuthChanged := cmd.Flags().Changed("registry-auth-id")
+	if registryAuthChanged {
+		value := strings.TrimSpace(updateRegistryAuthID)
+		req.ContainerRegistryAuthID = &value
+	}
+
+	hasRESTUpdate := req.Name != "" || req.ImageName != "" || req.Ports != nil || req.Env != nil || req.Readme != "" ||
+		req.ContainerDiskInGb != nil || req.ContainerRegistryAuthID != nil
+
+	var template *api.Template
+	if portLabelsChanged && !hasRESTUpdate {
+		template, err = client.GetTemplate(templateID)
+	} else {
+		template, err = client.UpdateTemplate(templateID, req)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to update template: %w", err)
 	}
 
+	if portLabelsChanged {
+		graphqlClient, graphqlErr := api.NewGraphQLClient()
+		if graphqlErr == nil {
+			graphqlErr = graphqlClient.UpdateTemplatePortLabels(templateID, portLabels, updatePortLabelOverrides(req))
+		}
+		if graphqlErr != nil {
+			if hasRESTUpdate {
+				return fmt.Errorf("template fields updated but failed to update port labels: %w", graphqlErr)
+			}
+			return fmt.Errorf("failed to update port labels: %w", graphqlErr)
+		}
+		template.PortsConfig = portLabels
+	}
+	if req.ContainerRegistryAuthID != nil {
+		template.ContainerRegistryAuthID = *req.ContainerRegistryAuthID
+	}
+
 	format := output.ParseFormat(cmd.Flag("output").Value.String())
 	return output.Print(template, &output.Config{Format: format})
+}
+
+func updatePortLabelOverrides(req *api.TemplateUpdateRequest) *api.TemplatePortLabelOverrides {
+	overrides := &api.TemplatePortLabelOverrides{
+		ContainerDiskInGb:       req.ContainerDiskInGb,
+		ContainerRegistryAuthID: req.ContainerRegistryAuthID,
+	}
+	if req.Name != "" {
+		overrides.Name = &req.Name
+	}
+	if req.ImageName != "" {
+		overrides.ImageName = &req.ImageName
+	}
+	if req.Ports != nil {
+		overrides.Ports = &req.Ports
+	}
+	if req.Env != nil {
+		overrides.Env = &req.Env
+	}
+	if req.Readme != "" {
+		overrides.Readme = &req.Readme
+	}
+	return overrides
 }

--- a/docs/runpodctl_template_create.md
+++ b/docs/runpodctl_template_create.md
@@ -10,6 +10,13 @@ create a new template
 runpodctl template create [flags]
 ```
 
+### Examples
+
+```
+  runpodctl template create --name private-gpu --image registry.example.com/team/image:tag --registry-auth-id <registry-auth-id>
+  runpodctl template create --name dev --image example/image:tag --ports "22/tcp,8888/http" --port-labels "22=ssh,8888=jupyter lab"
+```
+
 ### Options
 
 ```
@@ -20,8 +27,10 @@ runpodctl template create [flags]
   -h, --help                       help for create
       --image string               docker image name (required)
       --name string                template name (required)
+      --port-labels string         port labels as port=name pairs or json
       --ports string               comma-separated list of ports
       --readme string              readme content
+      --registry-auth-id string    container registry auth id (from 'runpodctl registry list')
       --serverless                 is this a serverless template
       --volume-in-gb int           volume size in gb
       --volume-mount-path string   volume mount path (default "/workspace")
@@ -36,4 +45,3 @@ runpodctl template create [flags]
 ### SEE ALSO
 
 * [runpodctl template](runpodctl_template.md)	 - manage templates
-

--- a/docs/runpodctl_template_update.md
+++ b/docs/runpodctl_template_update.md
@@ -10,6 +10,13 @@ update an existing template
 runpodctl template update <template-id> [flags]
 ```
 
+### Examples
+
+```
+  runpodctl template update <template-id> --registry-auth-id <registry-auth-id>
+  runpodctl template update <template-id> --port-labels "22=ssh,8888=jupyter lab"
+```
+
 ### Options
 
 ```
@@ -18,8 +25,10 @@ runpodctl template update <template-id> [flags]
   -h, --help                       help for update
       --image string               new docker image name
       --name string                new template name
+      --port-labels string         new port labels as port=name pairs or json; pass an empty value to clear
       --ports string               new comma-separated list of ports
       --readme string              new readme content
+      --registry-auth-id string    new container registry auth id; pass an empty value to clear
 ```
 
 ### Options inherited from parent commands
@@ -31,4 +40,3 @@ runpodctl template update <template-id> [flags]
 ### SEE ALSO
 
 * [runpodctl template](runpodctl_template.md)	 - manage templates
-

--- a/internal/api/template_port_labels.go
+++ b/internal/api/template_port_labels.go
@@ -1,0 +1,335 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// TemplatePortLabelOverrides contains template values changed immediately
+// before a portsConfig mutation. Applying them avoids reverting a fresh REST
+// update when GraphQL reads are briefly stale.
+type TemplatePortLabelOverrides struct {
+	Name                    *string
+	ImageName               *string
+	IsServerless            *bool
+	Ports                   *[]string
+	Env                     *map[string]string
+	ContainerDiskInGb       *int
+	ContainerRegistryAuthID *string
+	VolumeInGb              *int
+	VolumeMountPath         *string
+	Readme                  *string
+}
+
+var errTemplateForPortLabelsNotFound = errors.New("template not found")
+
+const (
+	templatePortLabelFetchAttempts = 10
+	templatePortLabelRetryDelay    = 250 * time.Millisecond
+)
+
+type templateSaveState struct {
+	ID                      string            `json:"id"`
+	Name                    string            `json:"name"`
+	ImageName               string            `json:"imageName"`
+	DockerArgs              string            `json:"dockerArgs"`
+	Env                     []templateEnvPair `json:"env"`
+	Ports                   templatePorts     `json:"ports"`
+	VolumeMountPath         string            `json:"volumeMountPath"`
+	VolumeInGb              int               `json:"volumeInGb"`
+	ContainerDiskInGb       int               `json:"containerDiskInGb"`
+	ContainerRegistryAuthID string            `json:"containerRegistryAuthId"`
+	StartJupyter            bool              `json:"startJupyter"`
+	StartSSH                bool              `json:"startSsh"`
+	StartScript             string            `json:"startScript"`
+	IsServerless            bool              `json:"isServerless"`
+	IsPublic                bool              `json:"isPublic"`
+	Readme                  string            `json:"readme"`
+	AdvancedStart           bool              `json:"advancedStart"`
+	Category                string            `json:"category"`
+}
+
+// UpdateTemplatePortLabels updates the dashboard labels for a template's
+// exposed ports. Port labels are available through GraphQL's portsConfig
+// field, but not through the public REST template schema.
+func (c *GraphQLClient) UpdateTemplatePortLabels(templateID string, labels []TemplatePortConfig, overrides *TemplatePortLabelOverrides) error {
+	var (
+		state *templateSaveState
+		err   error
+	)
+
+	for attempt := 0; attempt < templatePortLabelFetchAttempts; attempt++ {
+		state, err = c.getTemplateSaveState(templateID)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, errTemplateForPortLabelsNotFound) {
+			return err
+		}
+		if attempt+1 < templatePortLabelFetchAttempts {
+			time.Sleep(templatePortLabelRetryDelay)
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	applyTemplatePortLabelOverrides(state, overrides)
+
+	normalizedLabels, err := normalizeTemplatePortLabels(labels, state.Ports)
+	if err != nil {
+		return err
+	}
+
+	env := state.Env
+	if env == nil {
+		env = []templateEnvPair{}
+	}
+
+	input := map[string]interface{}{
+		"id":                      state.ID,
+		"name":                    state.Name,
+		"imageName":               state.ImageName,
+		"containerDiskInGb":       state.ContainerDiskInGb,
+		"containerRegistryAuthId": state.ContainerRegistryAuthID,
+		"dockerArgs":              state.DockerArgs,
+		"env":                     env,
+		"ports":                   strings.Join([]string(state.Ports), ","),
+		"portsConfig":             normalizedLabels,
+		"volumeInGb":              state.VolumeInGb,
+		"isPublic":                state.IsPublic,
+		"isServerless":            state.IsServerless,
+		"startJupyter":            state.StartJupyter,
+		"startSsh":                state.StartSSH,
+		"advancedStart":           state.AdvancedStart,
+		"readme":                  state.Readme,
+	}
+	if state.VolumeMountPath != "" {
+		input["volumeMountPath"] = state.VolumeMountPath
+	}
+	if state.StartScript != "" {
+		input["startScript"] = state.StartScript
+	}
+	if state.Category != "" {
+		input["category"] = state.Category
+	}
+
+	body, err := c.Query(GraphQLInput{
+		Query: `
+		mutation UpdateTemplatePortLabels($input: SaveTemplateInput) {
+			saveTemplate(input: $input) {
+				id
+			}
+		}
+		`,
+		Variables: map[string]interface{}{"input": input},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update template port labels: %w", err)
+	}
+
+	var response struct {
+		Data struct {
+			SaveTemplate *struct {
+				ID string `json:"id"`
+			} `json:"saveTemplate"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return fmt.Errorf("failed to parse template port label response: %w", err)
+	}
+	if len(response.Errors) > 0 {
+		return fmt.Errorf("graphql error: %s", response.Errors[0].Message)
+	}
+	if response.Data.SaveTemplate == nil || response.Data.SaveTemplate.ID == "" {
+		return errors.New("template port label update returned an empty response")
+	}
+
+	return nil
+}
+
+func (c *GraphQLClient) getTemplateSaveState(templateID string) (*templateSaveState, error) {
+	body, err := c.Query(GraphQLInput{
+		Query: `
+		query GetTemplateForPortLabels {
+			myself {
+				podTemplates {
+					id
+					name
+					imageName
+					dockerArgs
+					env {
+						key
+						value
+					}
+					ports
+					volumeMountPath
+					volumeInGb
+					containerDiskInGb
+					containerRegistryAuthId
+					startJupyter
+					startSsh
+					startScript
+					isServerless
+					isPublic
+					readme
+					advancedStart
+					category
+				}
+			}
+		}
+		`,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get template for port label update: %w", err)
+	}
+
+	var response struct {
+		Data struct {
+			Myself struct {
+				PodTemplates []templateSaveState `json:"podTemplates"`
+			} `json:"myself"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse template response: %w", err)
+	}
+	if len(response.Errors) > 0 {
+		return nil, fmt.Errorf("graphql error: %s", response.Errors[0].Message)
+	}
+
+	for i := range response.Data.Myself.PodTemplates {
+		if response.Data.Myself.PodTemplates[i].ID == templateID {
+			return &response.Data.Myself.PodTemplates[i], nil
+		}
+	}
+
+	return nil, fmt.Errorf("%w: %s", errTemplateForPortLabelsNotFound, templateID)
+}
+
+func applyTemplatePortLabelOverrides(state *templateSaveState, overrides *TemplatePortLabelOverrides) {
+	if state == nil || overrides == nil {
+		return
+	}
+	if overrides.Name != nil {
+		state.Name = *overrides.Name
+	}
+	if overrides.ImageName != nil {
+		state.ImageName = *overrides.ImageName
+	}
+	if overrides.IsServerless != nil {
+		state.IsServerless = *overrides.IsServerless
+	}
+	if overrides.Ports != nil {
+		state.Ports = append(templatePorts(nil), (*overrides.Ports)...)
+	}
+	if overrides.Env != nil {
+		state.Env = templateEnvPairs(*overrides.Env)
+	}
+	if overrides.ContainerDiskInGb != nil {
+		state.ContainerDiskInGb = *overrides.ContainerDiskInGb
+	}
+	if overrides.ContainerRegistryAuthID != nil {
+		state.ContainerRegistryAuthID = *overrides.ContainerRegistryAuthID
+	}
+	if overrides.VolumeInGb != nil {
+		state.VolumeInGb = *overrides.VolumeInGb
+	}
+	if overrides.VolumeMountPath != nil {
+		state.VolumeMountPath = *overrides.VolumeMountPath
+	}
+	if overrides.Readme != nil {
+		state.Readme = *overrides.Readme
+	}
+}
+
+func templateEnvPairs(env map[string]string) []templateEnvPair {
+	if len(env) == 0 {
+		return []templateEnvPair{}
+	}
+
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	pairs := make([]templateEnvPair, 0, len(keys))
+	for _, key := range keys {
+		pairs = append(pairs, templateEnvPair{Key: key, Value: env[key]})
+	}
+	return pairs
+}
+
+func normalizeTemplatePortLabels(labels []TemplatePortConfig, ports templatePorts) ([]TemplatePortConfig, error) {
+	available := make(map[string]struct{}, len(ports))
+	for _, rawPort := range ports {
+		port, err := templatePortNumber(rawPort)
+		if err != nil {
+			return nil, fmt.Errorf("template has invalid port %q: %w", rawPort, err)
+		}
+		available[port] = struct{}{}
+	}
+
+	if labels == nil {
+		return []TemplatePortConfig{}, nil
+	}
+
+	normalized := make([]TemplatePortConfig, 0, len(labels))
+	seen := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		port, err := templatePortNumber(label.Port)
+		if err != nil {
+			return nil, err
+		}
+		name := strings.TrimSpace(label.Name)
+		if name == "" {
+			return nil, fmt.Errorf("port label name is required for port %s", port)
+		}
+		if _, exists := seen[port]; exists {
+			return nil, fmt.Errorf("duplicate port label for %s", port)
+		}
+		if _, exists := available[port]; !exists {
+			return nil, fmt.Errorf("port label %s does not match any template port", port)
+		}
+		seen[port] = struct{}{}
+		normalized = append(normalized, TemplatePortConfig{Port: port, Name: name})
+	}
+
+	return normalized, nil
+}
+
+func templatePortNumber(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	parts := strings.Split(value, "/")
+	if len(parts) > 2 {
+		return "", fmt.Errorf("invalid port %q", raw)
+	}
+	if len(parts) == 2 {
+		protocol := strings.ToLower(strings.TrimSpace(parts[1]))
+		if protocol != "tcp" && protocol != "http" {
+			return "", fmt.Errorf("unsupported protocol %q for port %s", protocol, strings.TrimSpace(parts[0]))
+		}
+	}
+
+	port, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return "", fmt.Errorf("invalid port %q", raw)
+	}
+	if port < 1 || port > 65535 {
+		return "", fmt.Errorf("port %d is outside the valid range 1-65535", port)
+	}
+
+	return strconv.Itoa(port), nil
+}

--- a/internal/api/template_port_labels_test.go
+++ b/internal/api/template_port_labels_test.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestUpdateTemplatePortLabelsPreservesStateAndAppliesOverrides(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		var request GraphQLInput
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		switch {
+		case strings.Contains(request.Query, "GetTemplateForPortLabels"):
+			_, _ = w.Write([]byte(`{
+				"data": {"myself": {"podTemplates": [{
+					"id": "tpl-123",
+					"name": "old-name",
+					"imageName": "old-image",
+					"dockerArgs": "--serve",
+					"env": [{"key": "OLD", "value": "1"}],
+					"ports": "22/tcp,8888/http",
+					"volumeMountPath": "/workspace",
+					"volumeInGb": 20,
+					"containerDiskInGb": 30,
+					"containerRegistryAuthId": "old-auth",
+					"startJupyter": true,
+					"startSsh": true,
+					"startScript": "echo ready",
+					"isServerless": false,
+					"isPublic": false,
+					"readme": "old readme",
+					"advancedStart": true,
+					"category": "NVIDIA"
+				}]}}
+			}`))
+		case strings.Contains(request.Query, "UpdateTemplatePortLabels"):
+			input, ok := request.Variables["input"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("input = %#v", request.Variables["input"])
+			}
+			assertStringValue(t, input, "name", "new-name")
+			assertStringValue(t, input, "imageName", "new-image")
+			assertStringValue(t, input, "containerRegistryAuthId", "new-auth")
+			assertStringValue(t, input, "ports", "22/tcp,9000/http")
+			assertStringValue(t, input, "dockerArgs", "--serve")
+			assertStringValue(t, input, "volumeMountPath", "/workspace")
+			assertStringValue(t, input, "startScript", "echo ready")
+			assertStringValue(t, input, "category", "NVIDIA")
+			if input["containerDiskInGb"] != float64(40) {
+				t.Fatalf("containerDiskInGb = %#v, want 40", input["containerDiskInGb"])
+			}
+
+			env, ok := input["env"].([]interface{})
+			if !ok || len(env) != 2 {
+				t.Fatalf("env = %#v, want two entries", input["env"])
+			}
+			firstEnv := env[0].(map[string]interface{})
+			secondEnv := env[1].(map[string]interface{})
+			if firstEnv["key"] != "A" || secondEnv["key"] != "Z" {
+				t.Fatalf("env order = %#v, want sorted keys", env)
+			}
+
+			labels, ok := input["portsConfig"].([]interface{})
+			if !ok || len(labels) != 2 {
+				t.Fatalf("portsConfig = %#v, want two labels", input["portsConfig"])
+			}
+			firstLabel := labels[0].(map[string]interface{})
+			secondLabel := labels[1].(map[string]interface{})
+			if firstLabel["port"] != "22" || firstLabel["name"] != "SSH" {
+				t.Fatalf("first label = %#v", firstLabel)
+			}
+			if secondLabel["port"] != "9000" || secondLabel["name"] != "API" {
+				t.Fatalf("second label = %#v", secondLabel)
+			}
+
+			_, _ = w.Write([]byte(`{"data":{"saveTemplate":{"id":"tpl-123"}}}`))
+		default:
+			t.Fatalf("unexpected graphql query: %s", request.Query)
+		}
+	}))
+	defer server.Close()
+
+	client := &GraphQLClient{
+		url:        server.URL,
+		apiKey:     "test-key",
+		httpClient: server.Client(),
+	}
+
+	newName := "new-name"
+	newImage := "new-image"
+	newPorts := []string{"22/tcp", "9000/http"}
+	newEnv := map[string]string{"Z": "26", "A": "1"}
+	newDiskSize := 40
+	newAuth := "new-auth"
+	err := client.UpdateTemplatePortLabels(
+		"tpl-123",
+		[]TemplatePortConfig{{Port: "22/tcp", Name: "SSH"}, {Port: "9000", Name: "API"}},
+		&TemplatePortLabelOverrides{
+			Name:                    &newName,
+			ImageName:               &newImage,
+			Ports:                   &newPorts,
+			Env:                     &newEnv,
+			ContainerDiskInGb:       &newDiskSize,
+			ContainerRegistryAuthID: &newAuth,
+		},
+	)
+	if err != nil {
+		t.Fatalf("UpdateTemplatePortLabels() error = %v", err)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, want 2", requestCount)
+	}
+}
+
+func TestUpdateTemplatePortLabelsRejectsUnknownPort(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		_, _ = w.Write([]byte(`{"data":{"myself":{"podTemplates":[{
+			"id":"tpl-123",
+			"name":"test",
+			"imageName":"image",
+			"dockerArgs":"",
+			"env":[],
+			"ports":"22/tcp",
+			"volumeInGb":0,
+			"containerDiskInGb":20
+		}]}}}`))
+	}))
+	defer server.Close()
+
+	client := &GraphQLClient{url: server.URL, apiKey: "test-key", httpClient: server.Client()}
+	err := client.UpdateTemplatePortLabels("tpl-123", []TemplatePortConfig{{Port: "8888", Name: "Jupyter"}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "does not match any template port") {
+		t.Fatalf("error = %v, want unknown port error", err)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount)
+	}
+}
+
+func TestTemplateFromGraphQLIncludesRegistryAuthAndPortLabels(t *testing.T) {
+	template := templateFromGraphQL(&templateGraphQL{
+		ID:                      "tpl-123",
+		ContainerRegistryAuthID: "registry-123",
+		PortsConfig:             []TemplatePortConfig{{Port: "22", Name: "SSH"}},
+	})
+	if template.ContainerRegistryAuthID != "registry-123" {
+		t.Fatalf("ContainerRegistryAuthID = %q", template.ContainerRegistryAuthID)
+	}
+	if len(template.PortsConfig) != 1 || template.PortsConfig[0].Name != "SSH" {
+		t.Fatalf("PortsConfig = %#v", template.PortsConfig)
+	}
+}
+
+func assertStringValue(t *testing.T, values map[string]interface{}, key, want string) {
+	t.Helper()
+	if got := values[key]; got != want {
+		t.Fatalf("%s = %#v, want %q", key, got, want)
+	}
+}

--- a/internal/api/template_registry_auth_test.go
+++ b/internal/api/template_registry_auth_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateTemplateIncludesRegistryAuthID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if got := payload["containerRegistryAuthId"]; got != "registry-123" {
+			t.Fatalf("containerRegistryAuthId = %#v, want registry-123", got)
+		}
+		_ = json.NewEncoder(w).Encode(Template{ID: "tpl-123"})
+	}))
+	defer server.Close()
+
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+	client, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	client.baseURL = server.URL
+
+	_, err = client.CreateTemplate(&TemplateCreateRequest{
+		Name:                    "private-template",
+		ImageName:               "registry.example.com/team/image:tag",
+		ContainerRegistryAuthID: "registry-123",
+	})
+	if err != nil {
+		t.Fatalf("CreateTemplate() error = %v", err)
+	}
+}
+
+func TestUpdateTemplateCanClearRegistryAuthID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("expected PATCH, got %s", r.Method)
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		value, exists := payload["containerRegistryAuthId"]
+		if !exists {
+			t.Fatal("expected containerRegistryAuthId to be present")
+		}
+		if value != "" {
+			t.Fatalf("containerRegistryAuthId = %#v, want empty string", value)
+		}
+		_ = json.NewEncoder(w).Encode(Template{ID: "tpl-123"})
+	}))
+	defer server.Close()
+
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+	client, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	client.baseURL = server.URL
+
+	empty := ""
+	_, err = client.UpdateTemplate("tpl-123", &TemplateUpdateRequest{
+		ContainerRegistryAuthID: &empty,
+	})
+	if err != nil {
+		t.Fatalf("UpdateTemplate() error = %v", err)
+	}
+}

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -6,23 +6,31 @@ import (
 	"strings"
 )
 
+// TemplatePortConfig represents a named port shown in the Runpod dashboard.
+type TemplatePortConfig struct {
+	Port string `json:"port"`
+	Name string `json:"name"`
+}
+
 // Template represents a runpod template
 type Template struct {
-	ID                string            `json:"id"`
-	Name              string            `json:"name"`
-	ImageName         string            `json:"imageName"`
-	IsServerless      bool              `json:"isServerless,omitempty"`
-	IsPublic          bool              `json:"isPublic,omitempty"`
-	IsRunpod          bool              `json:"isRunpod,omitempty"`
-	Category          string            `json:"category,omitempty"`
-	Ports             []string          `json:"ports,omitempty"`
-	DockerEntrypoint  []string          `json:"dockerEntrypoint,omitempty"`
-	DockerStartCmd    []string          `json:"dockerStartCmd,omitempty"`
-	Env               map[string]string `json:"env,omitempty"`
-	ContainerDiskInGb int               `json:"containerDiskInGb,omitempty"`
-	VolumeInGb        int               `json:"volumeInGb,omitempty"`
-	VolumeMountPath   string            `json:"volumeMountPath,omitempty"`
-	Readme            string            `json:"readme,omitempty"`
+	ID                      string               `json:"id"`
+	Name                    string               `json:"name"`
+	ImageName               string               `json:"imageName"`
+	IsServerless            bool                 `json:"isServerless,omitempty"`
+	IsPublic                bool                 `json:"isPublic,omitempty"`
+	IsRunpod                bool                 `json:"isRunpod,omitempty"`
+	Category                string               `json:"category,omitempty"`
+	Ports                   []string             `json:"ports,omitempty"`
+	PortsConfig             []TemplatePortConfig `json:"portsConfig,omitempty"`
+	DockerEntrypoint        []string             `json:"dockerEntrypoint,omitempty"`
+	DockerStartCmd          []string             `json:"dockerStartCmd,omitempty"`
+	Env                     map[string]string    `json:"env,omitempty"`
+	ContainerDiskInGb       int                  `json:"containerDiskInGb,omitempty"`
+	ContainerRegistryAuthID string               `json:"containerRegistryAuthId,omitempty"`
+	VolumeInGb              int                  `json:"volumeInGb,omitempty"`
+	VolumeMountPath         string               `json:"volumeMountPath,omitempty"`
+	Readme                  string               `json:"readme,omitempty"`
 }
 
 type templateEnvPair struct {
@@ -67,19 +75,21 @@ func (p *templatePorts) UnmarshalJSON(data []byte) error {
 }
 
 type templateGraphQL struct {
-	ID                string            `json:"id"`
-	Name              string            `json:"name"`
-	ImageName         string            `json:"imageName"`
-	IsServerless      bool              `json:"isServerless,omitempty"`
-	IsPublic          bool              `json:"isPublic,omitempty"`
-	IsRunpod          bool              `json:"isRunpod,omitempty"`
-	Category          string            `json:"category,omitempty"`
-	Ports             templatePorts     `json:"ports,omitempty"`
-	Env               []templateEnvPair `json:"env,omitempty"`
-	ContainerDiskInGb int               `json:"containerDiskInGb,omitempty"`
-	VolumeInGb        int               `json:"volumeInGb,omitempty"`
-	VolumeMountPath   string            `json:"volumeMountPath,omitempty"`
-	Readme            string            `json:"readme,omitempty"`
+	ID                      string               `json:"id"`
+	Name                    string               `json:"name"`
+	ImageName               string               `json:"imageName"`
+	IsServerless            bool                 `json:"isServerless,omitempty"`
+	IsPublic                bool                 `json:"isPublic,omitempty"`
+	IsRunpod                bool                 `json:"isRunpod,omitempty"`
+	Category                string               `json:"category,omitempty"`
+	Ports                   templatePorts        `json:"ports,omitempty"`
+	PortsConfig             []TemplatePortConfig `json:"portsConfig,omitempty"`
+	Env                     []templateEnvPair    `json:"env,omitempty"`
+	ContainerDiskInGb       int                  `json:"containerDiskInGb,omitempty"`
+	ContainerRegistryAuthID string               `json:"containerRegistryAuthId,omitempty"`
+	VolumeInGb              int                  `json:"volumeInGb,omitempty"`
+	VolumeMountPath         string               `json:"volumeMountPath,omitempty"`
+	Readme                  string               `json:"readme,omitempty"`
 }
 
 // TemplateType for filtering
@@ -107,27 +117,29 @@ type TemplateListResponse struct {
 
 // TemplateCreateRequest is the request to create a template
 type TemplateCreateRequest struct {
-	Name              string            `json:"name"`
-	ImageName         string            `json:"imageName"`
-	IsServerless      bool              `json:"isServerless,omitempty"`
-	Ports             []string          `json:"ports,omitempty"`
-	DockerEntrypoint  []string          `json:"dockerEntrypoint,omitempty"`
-	DockerStartCmd    []string          `json:"dockerStartCmd,omitempty"`
-	Env               map[string]string `json:"env,omitempty"`
-	ContainerDiskInGb int               `json:"containerDiskInGb,omitempty"`
-	VolumeInGb        int               `json:"volumeInGb,omitempty"`
-	VolumeMountPath   string            `json:"volumeMountPath,omitempty"`
-	Readme            string            `json:"readme,omitempty"`
+	Name                    string            `json:"name"`
+	ImageName               string            `json:"imageName"`
+	IsServerless            bool              `json:"isServerless,omitempty"`
+	Ports                   []string          `json:"ports,omitempty"`
+	DockerEntrypoint        []string          `json:"dockerEntrypoint,omitempty"`
+	DockerStartCmd          []string          `json:"dockerStartCmd,omitempty"`
+	Env                     map[string]string `json:"env,omitempty"`
+	ContainerDiskInGb       int               `json:"containerDiskInGb,omitempty"`
+	ContainerRegistryAuthID string            `json:"containerRegistryAuthId,omitempty"`
+	VolumeInGb              int               `json:"volumeInGb,omitempty"`
+	VolumeMountPath         string            `json:"volumeMountPath,omitempty"`
+	Readme                  string            `json:"readme,omitempty"`
 }
 
 // TemplateUpdateRequest is the request to update a template
 type TemplateUpdateRequest struct {
-	Name              string            `json:"name,omitempty"`
-	ImageName         string            `json:"imageName,omitempty"`
-	Ports             []string          `json:"ports,omitempty"`
-	Env               map[string]string `json:"env,omitempty"`
-	Readme            string            `json:"readme,omitempty"`
-	ContainerDiskInGb *int              `json:"containerDiskInGb,omitempty"`
+	Name                    string            `json:"name,omitempty"`
+	ImageName               string            `json:"imageName,omitempty"`
+	Ports                   []string          `json:"ports,omitempty"`
+	Env                     map[string]string `json:"env,omitempty"`
+	Readme                  string            `json:"readme,omitempty"`
+	ContainerDiskInGb       *int              `json:"containerDiskInGb,omitempty"`
+	ContainerRegistryAuthID *string           `json:"containerRegistryAuthId,omitempty"`
 }
 
 // ListTemplates returns templates (user's own via REST API)
@@ -283,11 +295,16 @@ func (c *Client) getTemplateByIDGraphQL(templateID string) (*Template, error) {
 				isRunpod
 				category
 				ports
+				portsConfig {
+					port
+					name
+				}
 				env {
 					key
 					value
 				}
 				containerDiskInGb
+				containerRegistryAuthId
 				volumeInGb
 				volumeMountPath
 				readme
@@ -334,18 +351,20 @@ func templateFromGraphQL(source *templateGraphQL) *Template {
 	}
 
 	template := &Template{
-		ID:                source.ID,
-		Name:              source.Name,
-		ImageName:         source.ImageName,
-		IsServerless:      source.IsServerless,
-		IsPublic:          source.IsPublic,
-		IsRunpod:          source.IsRunpod,
-		Category:          source.Category,
-		Ports:             []string(source.Ports),
-		ContainerDiskInGb: source.ContainerDiskInGb,
-		VolumeInGb:        source.VolumeInGb,
-		VolumeMountPath:   source.VolumeMountPath,
-		Readme:            source.Readme,
+		ID:                      source.ID,
+		Name:                    source.Name,
+		ImageName:               source.ImageName,
+		IsServerless:            source.IsServerless,
+		IsPublic:                source.IsPublic,
+		IsRunpod:                source.IsRunpod,
+		Category:                source.Category,
+		Ports:                   []string(source.Ports),
+		PortsConfig:             source.PortsConfig,
+		ContainerDiskInGb:       source.ContainerDiskInGb,
+		ContainerRegistryAuthID: source.ContainerRegistryAuthID,
+		VolumeInGb:              source.VolumeInGb,
+		VolumeMountPath:         source.VolumeMountPath,
+		Readme:                  source.Readme,
 	}
 
 	if len(source.Env) > 0 {


### PR DESCRIPTION
## summary

- add `--registry-auth-id` to `template create` and `template update`
- allow `template update --registry-auth-id ""` to detach registry credentials
- add `--port-labels` to template create/update, with shorthand (`22=ssh,8888=jupyter lab`) and JSON forms
- expose `containerRegistryAuthId` and `portsConfig` in template output

## implementation

registry auth is sent through the existing REST template create/update paths.

port labels use the GraphQL `portsConfig` field through a narrow supplemental `saveTemplate` mutation. before that mutation, the CLI loads and preserves the complete existing template state. values changed by the immediately preceding REST request are overlaid so a briefly stale GraphQL read cannot undo the update.

create validates labels against `--ports` and removes the newly created template if the label mutation fails. update supports clearing labels with `--port-labels ""` and reports when REST fields succeeded but the label mutation failed.

## examples

```bash
runpodctl template create \
  --name private-gpu \
  --image registry.example.com/team/image:tag \
  --registry-auth-id <registry-auth-id> \
  --ports "22/tcp,8888/http" \
  --port-labels "22=ssh,8888=jupyter lab"

runpodctl template update <template-id> \
  --registry-auth-id <registry-auth-id> \
  --port-labels '{"22":"ssh","8888":"jupyter lab"}'
```

## validation

- added unit coverage for REST registry-auth serialization, including clearing
- added parser and validation coverage for pair and JSON port-label syntax
- added GraphQL request coverage proving existing template state is preserved and fresh REST values are overlaid
- targeted build/test/vet harnesses pass locally
- live e2e was not run because no `RUNPOD_API_KEY` is available in this environment
