### PR TITLE
fix: fix serverless network volume decoding

### DIFF
--- a/internal/api/endpoints.go
+++ b/internal/api/endpoints.go
@@ -38,6 +38,24 @@ type EndpointNetworkVolume struct {
 	DataCenterID    string `json:"dataCenterId,omitempty"`
 }
 
+// EndpointNetworkVolume accepts both the REST list item shape (string) and the
+// GraphQL list item shape (object) for multi-region endpoint volumes.
+func (v *EndpointNetworkVolume) UnmarshalJSON(data []byte) error {
+	var id string
+	if err := json.Unmarshal(data, &id); err == nil {
+		*v = EndpointNetworkVolume{NetworkVolumeID: id}
+		return nil
+	}
+
+	type endpointNetworkVolume EndpointNetworkVolume
+	var volume endpointNetworkVolume
+	if err := json.Unmarshal(data, &volume); err != nil {
+		return err
+	}
+	*v = EndpointNetworkVolume(volume)
+	return nil
+}
+
 // EndpointListResponse is the response from listing endpoints
 type EndpointListResponse struct {
 	Endpoints []Endpoint `json:"endpoints"`

--- a/internal/api/endpoints_test.go
+++ b/internal/api/endpoints_test.go
@@ -36,6 +36,39 @@ func TestListEndpoints(t *testing.T) {
 	}
 }
 
+func TestListEndpointsAcceptsStringNetworkVolumeIDs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/endpoints" {
+			t.Errorf("expected /endpoints, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[
+			{"id":"ep-1","name":"endpoint-1","networkVolumeIds":["vol-1","vol-2"]},
+			{"id":"ep-2","name":"endpoint-2","networkVolumeIds":[{"networkVolumeId":"vol-3","dataCenterId":"us-1"}]}
+		]`))
+	}))
+	defer server.Close()
+
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	client, _ := NewClient()
+	client.baseURL = server.URL
+
+	endpoints, err := client.ListEndpoints(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := endpoints[0].NetworkVolumeIDs[0].NetworkVolumeID; got != "vol-1" {
+		t.Fatalf("expected vol-1, got %s", got)
+	}
+	if got := endpoints[0].NetworkVolumeIDs[1].NetworkVolumeID; got != "vol-2" {
+		t.Fatalf("expected vol-2, got %s", got)
+	}
+	if got := endpoints[1].NetworkVolumeIDs[0].DataCenterID; got != "us-1" {
+		t.Fatalf("expected us-1, got %s", got)
+	}
+}
+
 func TestGetEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/endpoints/ep-123" {


### PR DESCRIPTION
## summary

- normalize `networkVolumeIds` decoding for serverless endpoints so rest string ids and graphql object entries both parse
- add regression coverage for `serverless list` responses containing attached network volumes

## root cause

`serverless list` decodes the rest `/endpoints` response into `Endpoint.NetworkVolumeIDs`, but the api can return `networkVolumeIds` as an array of strings while the client expected an array of objects. that made accounts with attached network volumes fail before output could be printed.

fixes #288

## validation

- `gocache=/tmp/go-build go test ./internal/api`
- `gocache=/tmp/go-build go build -o /tmp/runpodctl-bin/runpodctl .`
- `/tmp/runpodctl-bin/runpodctl serverless list` against the live api

## AI Disclaimer

Full disclaimer: I used AI for this and I'm not a Go pro, so I'm open to feedback, but looks reasonable to me.